### PR TITLE
Fix compilation error in RDK platform mock

### DIFF
--- a/rdk/ORB/src/platformMock/ORBPlatformImpl.cpp
+++ b/rdk/ORB/src/platformMock/ORBPlatformImpl.cpp
@@ -728,11 +728,11 @@ bool ORBPlatformImpl::ParentalControl_IsRatingBlocked(std::string scheme, std::s
 {
   bool blocked = true;
 
-  std::string thresholdRegion = toLower(ParentalControl_GetRegion());
+  std::string thresholdRegion = ToLower(ParentalControl_GetRegion());
   int thresholdAge = ParentalControl_GetAge();
 
   if (scheme == "dvb-si") {
-    if (thresholdRegion == toLower(region) && thresholdAge > value + 3) {
+    if (thresholdRegion == ToLower(region) && thresholdAge > value + 3) {
       blocked = false;
     }
   }
@@ -782,7 +782,7 @@ std::vector<std::string> ORBPlatformImpl::Programme_GetSiDescriptors(
  *
  * @return  The lowercase version of the provided string
  */
-std::string ORBPlatformImpl::toLower(const std::string &data)
+std::string ORBPlatformImpl::ToLower(const std::string &data)
 {
   std::string tmp = data;
   std::transform(tmp.begin(), tmp.end(), tmp.begin(),

--- a/rdk/ORB/src/platformMock/ORBPlatformImpl.h
+++ b/rdk/ORB/src/platformMock/ORBPlatformImpl.h
@@ -77,5 +77,5 @@ public:
   virtual std::vector<std::string> Programme_GetSiDescriptors(std::string ccid, std::string programmeId, int descriptorTag, int descriptorTagExtension, int privateDataSpecifier) override;
 
 private:
-  std::string toLower(const std::string& data);
+  std::string ToLower(const std::string& data);
 };


### PR DESCRIPTION
Fix error preventing compilation of platformMock for RDK.

`std::tolower` only converts individual characters to lowercase, not whole strings. Add a simple function to convert strings to lowercase and allow the code to compile.