### PR TITLE
Fix for uncalled service callback for App2AppService.

### DIFF
--- a/components/network_services/app2app/app2app_local_service.cpp
+++ b/components/network_services/app2app/app2app_local_service.cpp
@@ -225,7 +225,7 @@ void App2AppLocalService::OnRemoteServiceStopped()
    if (!service_stopped_)
    {
       service_stopped_ = true;
-      Stop();
+      WebSocketService::Stop();
    }
    else
    {


### PR DESCRIPTION
Between each android application instance, its resources get released and all running services are stopped. When each service is stopped, a callback is called releasing more resources if needed. For App2AppService, its callback was not being called, and as a result the subsequent applications could not instantiate an App2AppService object.

The problem was in the App2AppLocalService::OnRemoteServiceStopped(), which called the overrided Stop() method and at its current state, no callback was being called.