### PR TITLE
On stop/end, reset the media element back to its initial state and fo…

### DIFF
--- a/src/objects/avcontrol.js
+++ b/src/objects/avcontrol.js
@@ -791,6 +791,8 @@ hbbtv.objects.AVControl = (function() {
       priv.connected = false;
       priv.seekPos = undefined;
       priv.speed = 0;
+      priv.videoElement.load();
+      priv.videoElement.src = '';
    }
 
    function initialise() {


### PR DESCRIPTION
…rce the media resource to be unloaded. Otherwise on some platforms (i.e. Broadcom) the decoder is unavilable for broadcast media