### PR TITLE
Replace selectComponent/unselectComponent in bridge and native implementations

### DIFF
--- a/android/tvbrowser/src/main/java/org/orbtv/tvbrowser/AbstractBridge.java
+++ b/android/tvbrowser/src/main/java/org/orbtv/tvbrowser/AbstractBridge.java
@@ -468,29 +468,38 @@ public abstract class AbstractBridge {
       String ccid, int type);
 
    /**
-    * Select the broadcast component with the given type, PID and optionally language.
+    * Override the default component selection of the terminal for the specified type.
+    *
+    * The component in the stream that has the specified PID, CTAG (if specified), and language (if
+    * specified) shall be selected. If pidOrSuspended equals 0, no component for the specified type
+    * shall be selected for presentation.
+    *
+    * Default component selection shall be restored for the specified type when
+    * restoreDefaultComponentSelection is called, the channel is changed, the application
+    * terminates, or the user selects a different track of the same type in the terminal UI.
     *
     * Security: FOR_BROADCAST_APP_ONLY.
     *
     * @param token The token associated with this request.
-    * @param type The type of the component to select (COMPONENT_TYPE_* code).
-    * @param pid The PID of the component to select.
-    * @param language Optionally, the language of the component to select; or an empty string
-    *    otherwise.
+    * @param type Type of component selection to override (COMPONENT_TYPE_* code).
+    * @param pidOrSuspended Component PID or 0 to suspend presentation.
+    * @param ctag Component CTAG or 0 if not specified.
+    * @param language Component language of an empty string if not specified.
     */
-   protected abstract void Broadcast_selectComponent(Token token, int type, int pid,
-      String language);
+   protected abstract void Broadcast_overrideDefaultComponentSelection(Token token, int type,
+      int pidOrSuspended, int ctag, String language);
 
    /**
-    * Unselect the broadcast component with the given type and PID.
+    * Restore the default component selection of the terminal for the specified type.
+    *
+    * If playback has already started, the presented component shall be updated.
     *
     * Security: FOR_BROADCAST_APP_ONLY.
     *
     * @param token The token associated with this request.
-    * @param type The type of the component to unselect (COMPONENT_TYPE_* code).
-    * @param pid The PID of the component to unselect.
+    * @param type Type of component selection override to clear (COMPONENT_TYPE_* code).
     */
-   protected abstract void Broadcast_unselectComponent(Token token, int type, int pid);
+   protected abstract void Broadcast_restoreDefaultComponentSelection(Token token, int type);
 
    /**
     * Start a metadata search.
@@ -1117,28 +1126,28 @@ public abstract class AbstractBridge {
             break;
          }
 
-         case "Broadcast.selectComponent": {
+         case "Broadcast.overrideDefaultComponentSelection": {
             if (!isRequestAllowed(token, SessionCallback.FOR_BROADCAST_APP_ONLY)) {
                response.put("error", "SecurityError");
                break;
             }
-            Broadcast_selectComponent(
+            Broadcast_overrideDefaultComponentSelection(
                token,
                params.getInt("type"),
-               params.getInt("pid"),
+               params.getInt("pidOrSuspended"),
+               params.getInt("ctag"),
                params.getString("language")
             );
             break;
          }
-         case "Broadcast.unselectComponent": {
+         case "Broadcast.restoreDefaultComponentSelection": {
             if (!isRequestAllowed(token, SessionCallback.FOR_BROADCAST_APP_ONLY)) {
                response.put("error", "SecurityError");
                break;
             }
-            Broadcast_unselectComponent(
+            Broadcast_restoreDefaultComponentSelection(
                token,
-               params.getInt("type"),
-               params.getInt("pid")
+               params.getInt("type")
             );
             break;
          }

--- a/android/tvbrowser/src/main/java/org/orbtv/tvbrowser/Bridge.java
+++ b/android/tvbrowser/src/main/java/org/orbtv/tvbrowser/Bridge.java
@@ -284,67 +284,43 @@ class Bridge extends AbstractBridge {
    }
 
    /**
-    * Select the broadcast component with the given type, PID and optionally language.
+    * Override the default component selection of the terminal for the specified type.
+    *
+    * The component in the stream that has the specified PID, CTAG (if specified), and language (if
+    * specified) shall be selected. If pidOrSuspended equals 0, no component for the specified type
+    * shall be selected for presentation.
+    *
+    * Default component selection shall be restored for the specified type when
+    * restoreDefaultComponentSelection is called, the channel is changed, the application
+    * terminates, or the user selects a different track of the same type in the terminal UI.
+    *
+    * If playback has already started, the presented component shall be updated.
     *
     * Security: FOR_BROADCAST_APP_ONLY.
     *
     * @param token The token associated with this request.
-    * @param type The type of the component to select (COMPONENT_TYPE_* code).
-    * @param pid The PID of the component to select.
-    * @param language Optionally, the language of the component to select; or an empty string
-    *    otherwise.
+    * @param type Type of component selection to override (COMPONENT_TYPE_* code).
+    * @param pidOrSuspended Component PID or 0 to suspend presentation.
+    * @param ctag Component CTAG or 0 if not specified.
+    * @param language Component language of an empty string if not specified.
     */
-   @Override
-   protected void Broadcast_selectComponent(Token token, int type, int pid, String language) {
-      // TODO Add 1:1 method to callback
-      switch (type) {
-         case TvBrowserTypes.COMPONENT_TYPE_VIDEO: {
-            mTvBrowserCallback.presentDvbVideo(pid);
-            break;
-         }
-         case TvBrowserTypes.COMPONENT_TYPE_AUDIO: {
-            mTvBrowserCallback.presentDvbAudio(pid, language);
-            break;
-         }
-         case TvBrowserTypes.COMPONENT_TYPE_SUBTITLE: {
-            mTvBrowserCallback.presentDvbSubtitles(pid);
-            break;
-         }
-      }
+   protected void Broadcast_overrideDefaultComponentSelection(Token token, int type,
+      int pidOrSuspended, int ctag, String language) {
+      mTvBrowserCallback.overrideDefaultComponentSelection(type, pidOrSuspended, ctag, language);
    }
 
    /**
-    * Unselect the broadcast component with the given type and PID.
+    * Restore the default component selection of the terminal for the specified type.
+    *
+    * If playback has already started, the presented component shall be updated.
     *
     * Security: FOR_BROADCAST_APP_ONLY.
     *
     * @param token The token associated with this request.
-    * @param type The type of the component to unselect (COMPONENT_TYPE_* code).
-    * @param pid The PID of the component to unselect.
+    * @param type Type of component selection override to clear (COMPONENT_TYPE_* code).
     */
-   @Override
-   protected void Broadcast_unselectComponent(Token token, int type, int pid) {
-      // TODO Add 1:1 method to callback
-      switch (type) {
-         case TvBrowserTypes.COMPONENT_TYPE_ANY: {
-            mTvBrowserCallback.stopDvbAudio();
-            mTvBrowserCallback.stopDvbVideo();
-            mTvBrowserCallback.stopDvbSubtitles();
-            break;
-         }
-         case TvBrowserTypes.COMPONENT_TYPE_VIDEO: {
-            mTvBrowserCallback.stopDvbVideo();
-            break;
-         }
-         case TvBrowserTypes.COMPONENT_TYPE_AUDIO: {
-            mTvBrowserCallback.stopDvbAudio();
-            break;
-         }
-         case TvBrowserTypes.COMPONENT_TYPE_SUBTITLE: {
-            mTvBrowserCallback.stopDvbSubtitles();
-            break;
-         }
-      }
+   protected void Broadcast_restoreDefaultComponentSelection(Token token, int type) {
+      mTvBrowserCallback.restoreDefaultComponentSelection(type);
    }
 
    /**

--- a/android/tvbrowser/src/main/java/org/orbtv/tvbrowser/TvBrowserCallback.java
+++ b/android/tvbrowser/src/main/java/org/orbtv/tvbrowser/TvBrowserCallback.java
@@ -93,50 +93,33 @@ public interface TvBrowserCallback {
    void setPresentationSuspended(boolean presentationSuspended);
 
    /**
-    * Instructs the controlling application to present the audio specified by its PID and language.
+    * Override the default component selection of the terminal for the specified type.
     *
-    * @param pid
-    * @param lang
-    * @return true on success, false otherwise
+    * The component in the stream that has the specified PID, CTAG (if specified), and language (if
+    * specified) shall be selected. If pidOrSuspended equals 0, no component for the specified type
+    * shall be selected for presentation.
+    *
+    * Default component selection shall be restored for the specified type when
+    * restoreDefaultComponentSelection is called, the channel is changed, the application
+    * terminates, or the user selects a different track of the same type in the terminal UI.
+    *
+    * If playback has already started, the presented component shall be updated.
+    *
+    * @param type Type of component selection to override (COMPONENT_TYPE_* code).
+    * @param pidOrSuspended Component PID or 0 to suspend presentation.
+    * @param ctag Component CTAG or 0 if not specified.
+    * @param language Component language of an empty string if not specified.
     */
-   boolean presentDvbAudio(int pid, String lang);
+   void overrideDefaultComponentSelection(int type, int pidOrSuspended, int ctag, String language);
 
    /**
-    * Instructs the controlling application to stop the audio presentation
+    * Restore the default component selection of the terminal for the specified type.
     *
-    * @return true on success, false otherwise
-    */
-   boolean stopDvbAudio();
-
-   /**
-    * Instructs the controlling application to present the video specified by its PID.
+    * If playback has already started, the presented component shall be updated.
     *
-    * @param pid
-    * @return true on success, false otherwise
+    * @param type Type of component selection override to clear (COMPONENT_TYPE_* code).
     */
-   boolean presentDvbVideo(int pid);
-
-   /**
-    * Instructs the controlling application to stop the video presentation
-    *
-    * @return true on success, false otherwise
-    */
-   boolean stopDvbVideo();
-
-   /**
-    * Instructs the controlling application to present the subtitles specified by its component tag.
-    *
-    * @param pid
-    * @return true on success, false otherwise
-    */
-   boolean presentDvbSubtitles(int pid);
-
-   /**
-    * Instructs the controlling application to stop the subtitle presentation
-    *
-    * @return true on success, false otherwise
-    */
-   boolean stopDvbSubtitles();
+   void restoreDefaultComponentSelection(int type);
 
    /**
     * Sets the presentation window of the DVB video. Values are in HbbTV 1280x720 coordinates.

--- a/android/tvbrowser/src/main/java/org/orbtv/tvbrowser/TvBrowserTypes.java
+++ b/android/tvbrowser/src/main/java/org/orbtv/tvbrowser/TvBrowserTypes.java
@@ -212,7 +212,6 @@ public class TvBrowserTypes {
       public boolean hearingImpaired; // Subtitle
       public boolean encrypted;
       public boolean active;
-      public boolean defaultComponent;
       public boolean hidden;
       public String label; // Subtitle
 
@@ -228,11 +227,10 @@ public class TvBrowserTypes {
        * @param encrypted
        * @param aspectRatio ASPECT_RATIO_4_3 or ASPECT_RATIO_16_9
        * @param active
-       * @param defaultComponent
        * @return
        */
       public static Component createVideoComponent(int componentTag, int pid, String encoding,
-         boolean encrypted, int aspectRatio, boolean active, boolean defaultComponent) {
+         boolean encrypted, int aspectRatio, boolean active) {
          Component c = new Component();
          c.componentType = COMPONENT_TYPE_VIDEO;
          c.componentTag = componentTag;
@@ -241,7 +239,6 @@ public class TvBrowserTypes {
          c.encrypted = encrypted;
          c.aspectRatio = aspectRatio;
          c.active = active;
-         c.defaultComponent = defaultComponent;
          c.hidden = false;
          return c;
       }
@@ -257,12 +254,11 @@ public class TvBrowserTypes {
        * @param audioDescription
        * @param audioChannels
        * @param active
-       * @param defaultComponent
        * @return
        */
       public static Component createAudioComponent(int componentTag, int pid, String encoding,
          boolean encrypted, String language, boolean audioDescription, int audioChannels,
-         boolean active, boolean defaultComponent) {
+         boolean active) {
          Component c = new Component();
          c.componentType = COMPONENT_TYPE_AUDIO;
          c.componentTag = componentTag;
@@ -273,7 +269,6 @@ public class TvBrowserTypes {
          c.audioDescription = audioDescription;
          c.audioChannels = audioChannels;
          c.active = active;
-         c.defaultComponent = defaultComponent;
          c.hidden = false;
          return c;
       }
@@ -289,12 +284,10 @@ public class TvBrowserTypes {
        * @param hearingImpaired
        * @param label
        * @param active
-       * @param defaultComponent
        * @return
        */
       public static Component createSubtitleComponent(int componentTag, int pid, String encoding,
-         boolean encrypted, String language, boolean hearingImpaired, String label, boolean active,
-         boolean defaultComponent) {
+         boolean encrypted, String language, boolean hearingImpaired, String label, boolean active) {
          Component c = new Component();
          c.componentType = COMPONENT_TYPE_SUBTITLE;
          c.componentTag = componentTag;
@@ -305,7 +298,6 @@ public class TvBrowserTypes {
          c.hearingImpaired = hearingImpaired;
          c.label = label;
          c.active = active;
-         c.defaultComponent = defaultComponent;
          c.hidden = false;
          return c;
       }
@@ -345,7 +337,6 @@ public class TvBrowserTypes {
             }
          }
          o.put("active", active);
-         o.put("default", defaultComponent);
          if (hidden) {
             o.put("hidden", true);
          }

--- a/android/tvbrowsershell/src/main/java/org/orbtv/tvbrowsershell/TestSuiteScenario.java
+++ b/android/tvbrowsershell/src/main/java/org/orbtv/tvbrowsershell/TestSuiteScenario.java
@@ -1,6 +1,7 @@
 package org.orbtv.tvbrowsershell;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -43,6 +44,20 @@ public class TestSuiteScenario {
          }
       }
       return false;
+   }
+
+   public void selectComponent(int type, int pidOrSuspend) {
+      if (mCurrentChannelIndex < 0) {
+         return;
+      }
+      MockChannel ch = mMockChannels.get(mCurrentChannelIndex);
+      for (int i = 0; i < ch.components.size(); i++) {
+         TvBrowserTypes.Component c = ch.components.get(i);
+         if (c.componentType == type) {
+            Log.d("TAG", "Setting pid " + c.pid + " to " + (c.pid == pidOrSuspend));
+            c.active = (c.pid == pidOrSuspend);
+         }
+      }
    }
 
    public TvBrowserTypes.Channel getCurrentChannel() {
@@ -151,8 +166,7 @@ public class TestSuiteScenario {
                   info.getString("aspectRatio").equals("16_9") ?
                      TvBrowserTypes.ASPECT_RATIO_16_9 :
                      TvBrowserTypes.ASPECT_RATIO_4_3,
-                  info.getBoolean("active"),
-                  info.getBoolean("defaultComponent")
+                  info.getBoolean("active")
                ));
                break;
             }
@@ -165,8 +179,7 @@ public class TestSuiteScenario {
                   info.getString("language"),
                   info.getBoolean("audioDescription"),
                   info.getInt("audioChannels"),
-                  info.getBoolean("active"),
-                  info.getBoolean("defaultComponent")
+                  info.getBoolean("active")
                );
                component.hidden = info.getBoolean("hidden"); // TODO Add to constructor
                components.add(component);
@@ -181,8 +194,7 @@ public class TestSuiteScenario {
                   info.getString("language"),
                   info.getBoolean("hearingImpaired"),
                   info.getString("label"),
-                  info.getBoolean("active"),
-                  info.getBoolean("defaultComponent")
+                  info.getBoolean("active")
                ));
                break;
             }

--- a/rdk/ORB/library/src/core/requestHandlers/BroadcastRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/BroadcastRequestHandler.cpp
@@ -22,8 +22,8 @@
 #define BROADCAST_SET_CHANNEL_TO_DSD "setChannelToDsd"
 #define BROADCAST_GET_PROGRAMMES "getProgrammes"
 #define BROADCAST_GET_COMPONENTS "getComponents"
-#define BROADCAST_SELECT_COMPONENT "selectComponent"
-#define BROADCAST_UNSELECT_COMPONENT "unselectComponent"
+#define BROADCAST_OVERRIDE_DEFAULT_COMPONENT_SELECTION "overrideDefaultComponentSelection"
+#define BROADCAST_RESTORE_DEFAULT_COMPONENT_SELECTION "restoreDefaultComponentSelection"
 #define BROADCAST_START_SEARCH "startSearch"
 #define BROADCAST_ABORT_SEARCH "abortSearch"
 #define BROADCAST_ADD_STREAM_EVENT_LISTENER "addStreamEventListener"
@@ -288,8 +288,8 @@ bool BroadcastRequestHandler::Handle(
          response.emplace("result", array);
       }
    }
-   // Broadcast.selectComponent
-   else if (method == BROADCAST_SELECT_COMPONENT)
+   // Broadcast.overrideDefaultComponentSelection
+   else if (method == BROADCAST_OVERRIDE_DEFAULT_COMPONENT_SELECTION)
    {
       if (!IsRequestAllowed(token, ApplicationManager::MethodRequirement::FOR_BROADCAST_APP_ONLY))
       {
@@ -298,12 +298,16 @@ bool BroadcastRequestHandler::Handle(
       else
       {
          int componentType = params.value("type", COMPONENT_TYPE_ANY);
-         int pid = params.value("pid", -1);
-         ORBEngine::GetSharedInstance().GetORBPlatform()->Broadcast_SelectComponent(componentType, pid);
+         int pid = params.value("pidOrSuspended", 0);
+         int ctag = params.value("ctag", 0);
+         std::string language = params.value("language", "");
+
+         ORBEngine::GetSharedInstance().GetORBPlatform()->Broadcast_OverrideDefaultComponentSelection(
+            componentType, pid, ctag, language);
       }
    }
-   // Broadcast.unselectComponent
-   else if (method == BROADCAST_UNSELECT_COMPONENT)
+   // Broadcast.restoreDefaultComponentSelection
+   else if (method == BROADCAST_RESTORE_DEFAULT_COMPONENT_SELECTION)
    {
       if (!IsRequestAllowed(token, ApplicationManager::MethodRequirement::FOR_BROADCAST_APP_ONLY))
       {
@@ -312,7 +316,7 @@ bool BroadcastRequestHandler::Handle(
       else
       {
          int componentType = params.value("type", -1);
-         ORBEngine::GetSharedInstance().GetORBPlatform()->Broadcast_UnselectComponent(componentType);
+         ORBEngine::GetSharedInstance().GetORBPlatform()->Broadcast_RestoreDefaultComponentSelection(componentType);
       }
    }
    // Broadcast.startSearch

--- a/rdk/ORB/library/src/core/utilities/JsonUtil.cpp
+++ b/rdk/ORB/library/src/core/utilities/JsonUtil.cpp
@@ -146,7 +146,6 @@ json JsonUtil::ComponentToJsonObject(Component component)
       json_videoComponent.emplace("encrypted", component.IsEncrypted());
       json_videoComponent.emplace("aspectRatio", component.GetAspectRatio());
       json_videoComponent.emplace("active", component.IsActive());
-      json_videoComponent.emplace("default", component.IsDefaultComponent());
       if (component.IsHidden())
       {
          json_videoComponent.emplace("hidden", true);
@@ -166,7 +165,6 @@ json JsonUtil::ComponentToJsonObject(Component component)
       json_audioComponent.emplace("audioDescription", component.HasAudioDescription());
       json_audioComponent.emplace("audioChannels", component.GetAudioChannels());
       json_audioComponent.emplace("active", component.IsActive());
-      json_audioComponent.emplace("default", component.IsDefaultComponent());
       if (component.IsHidden())
       {
          json_audioComponent.emplace("hidden", true);
@@ -186,7 +184,6 @@ json JsonUtil::ComponentToJsonObject(Component component)
       json_subtitleComponent.emplace("hearingImpaired", component.IsHearingImpaired());
       json_subtitleComponent.emplace("label", component.GetLabel());
       json_subtitleComponent.emplace("active", component.IsActive());
-      json_subtitleComponent.emplace("default", component.IsDefaultComponent());
       if (component.IsHidden())
       {
          json_subtitleComponent.emplace("hidden", true);

--- a/rdk/ORB/library/src/core/utilities/SHA256.cpp
+++ b/rdk/ORB/library/src/core/utilities/SHA256.cpp
@@ -12,7 +12,7 @@
 #define uchar unsigned char
 #define uint unsigned int
 
-#define DBL_INT_ADD(a, b, c) if (a > 0xffffffff - (c))++ b; a += c;
+#define DBL_INT_ADD(a, b, c) if (a > 0xffffffff - (c)) ++b; a += c;
 #define ROTLEFT(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
 #define ROTRIGHT(a, b) (((a) >> (b)) | ((a) << (32 - (b))))
 

--- a/rdk/ORB/library/src/platform/ORBPlatform.h
+++ b/rdk/ORB/library/src/platform/ORBPlatform.h
@@ -263,20 +263,35 @@ public:
    virtual std::vector<Component> Broadcast_GetComponents(std::string ccid, int componentType) = 0;
 
    /**
-    * Select the specified component of the currently tuned broadcast channel.
+    * Override the default component selection of the terminal for the specified type.
     *
-    * @param componentType The component type (0: video, 1: audio, 2: subtitle)
-    * @param pid           The component's pid used as identifier
+    * The component in the stream that has the specified PID, CTAG (if specified), and language (if
+    * specified) shall be selected. If pidOrSuspended equals 0, no component for the specified type
+    * shall be selected for presentation.
+    *
+    * Default component selection shall be restored for the specified type when
+    * restoreDefaultComponentSelection is called, the channel is changed, the application
+    * terminates, or the user selects a different track of the same type in the terminal UI.
+    *
+    * Security: FOR_BROADCAST_APP_ONLY
+    *
+    * @param componentType  The component type (0: video, 1: audio, 2: subtitle)
+    * @param pidOrSuspended The component PID or 0 to suspend presentation
+    * @param ctag           The component tag or 0 if not specified
+    * @param language       The component language or an empty string if not specified
     */
-   virtual void Broadcast_SelectComponent(int componentType, int pid) = 0;
+   virtual void Broadcast_OverrideDefaultComponentSelection(int componentType, int pidOrSuspended, int ctag, std::string language) = 0;
 
    /**
-    * Unselect any currently selected component of the given type for the
-    * currently tuned broadcast channel.
+    * Restore the default component selection of the terminal for the specified type.
     *
-    * @param componentType The componentType (0: video, 1: audio, 2: subtitle)
+    * If playback has already started, the presented component shall be updated.
+    *
+    * Security: FOR_BROADCAST_APP_ONLY
+    *
+    * @param componentType The component type (0: video, 1: audio, 2: subtitle)
     */
-   virtual void Broadcast_UnselectComponent(int componentType) = 0;
+   virtual void Broadcast_RestoreDefaultComponentSelection(int componentType) = 0;
 
    /**
     * Suspend/resume the presentation of the current broadcast playback.

--- a/rdk/ORB/library/src/platform/dataTypes/Component.h
+++ b/rdk/ORB/library/src/platform/dataTypes/Component.h
@@ -36,7 +36,6 @@ public:
     * @param encoding         The encoding of the stream
     * @param encrypted        Flag indicating whether the component is encrypted or not
     * @param active
-    * @param defaultComponent
     * @param hidden
     * @param aspectRatio      Indicates the aspect ratio of the video
     *
@@ -48,7 +47,6 @@ public:
       std::string encoding,
       bool encrypted,
       bool active,
-      bool defaultComponent,
       bool hidden,
       float aspectRatio
       )
@@ -59,7 +57,6 @@ public:
          encoding,
          encrypted,
          active,
-         defaultComponent,
          hidden,
          aspectRatio
          );
@@ -74,7 +71,6 @@ public:
     * @param encoding         The encoding of the stream
     * @param encrypted        Flag indicating whether the component is encrypted or not
     * @param active
-    * @param defaultComponent
     * @param hidden
     * @param language         An ISO 639-2 language code representing the language of the stream
     * @param audioDescription Has value true if the stream contains an audio description intended
@@ -89,7 +85,6 @@ public:
       std::string encoding,
       bool encrypted,
       bool active,
-      bool defaultComponent,
       bool hidden,
       std::string language,
       bool audioDescription,
@@ -102,7 +97,6 @@ public:
          encoding,
          encrypted,
          active,
-         defaultComponent,
          hidden,
          language,
          audioDescription,
@@ -119,7 +113,6 @@ public:
     * @param encoding         The encoding of the stream
     * @param encrypted        Flag indicating whether the component is encrypted or not
     * @param active
-    * @param defaultComponent
     * @param hidden
     * @param language         An ISO 639-2 language code representing the language of the stream
     * @param hearingImpaired  Has value true if the stream is intended for the hearing-impaired
@@ -135,7 +128,6 @@ public:
       std::string encoding,
       bool encrypted,
       bool active,
-      bool defaultComponent,
       bool hidden,
       std::string language,
       bool hearingImpaired,
@@ -148,7 +140,6 @@ public:
          encoding,
          encrypted,
          active,
-         defaultComponent,
          hidden,
          language,
          hearingImpaired,
@@ -164,7 +155,6 @@ public:
     * @param encoding
     * @param encrypted
     * @param active
-    * @param defaultComponent
     * @param hidden
     * @param aspectRatio
     */
@@ -174,7 +164,6 @@ public:
       std::string encoding,
       bool encrypted,
       bool active,
-      bool defaultComponent,
       bool hidden,
       float aspectRatio
       )
@@ -185,7 +174,6 @@ public:
       m_encoding = encoding;
       m_encrypted = encrypted;
       m_active = active;
-      m_defaultComponent = defaultComponent;
       m_hidden = hidden;
       m_aspectRatio = aspectRatio;
    }
@@ -198,7 +186,6 @@ public:
     * @param encoding
     * @param encrypted
     * @param active
-    * @param defaultComponent
     * @param hidden
     * @param language
     * @param audioDescription
@@ -210,7 +197,6 @@ public:
       std::string encoding,
       bool encrypted,
       bool active,
-      bool defaultComponent,
       bool hidden,
       std::string language,
       bool audioDescription,
@@ -223,7 +209,6 @@ public:
       m_encoding = encoding;
       m_encrypted = encrypted;
       m_active = active;
-      m_defaultComponent = defaultComponent;
       m_hidden = hidden;
       m_language = language;
       m_audioDescription = audioDescription;
@@ -238,7 +223,6 @@ public:
     * @param encoding
     * @param encrypted
     * @param active
-    * @param defaultComponent
     * @param hidden
     * @param language
     * @param hearingImpaired
@@ -250,7 +234,6 @@ public:
       std::string encoding,
       bool encrypted,
       bool active,
-      bool defaultComponent,
       bool hidden,
       std::string language,
       bool hearingImpaired,
@@ -263,7 +246,6 @@ public:
       m_encoding = encoding;
       m_encrypted = encrypted;
       m_active = active;
-      m_defaultComponent = defaultComponent;
       m_hidden = hidden;
       m_language = language;
       m_hearingImpaired = hearingImpaired;
@@ -305,11 +287,6 @@ public:
    bool IsActive() const
    {
       return m_active;
-   }
-
-   bool IsDefaultComponent() const
-   {
-      return m_defaultComponent;
    }
 
    bool IsHidden() const
@@ -356,7 +333,6 @@ private:
    std::string m_encoding;
    bool m_encrypted;
    bool m_active;
-   bool m_defaultComponent;
    bool m_hidden;
 
    // audio/subtitle attributes

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
@@ -350,24 +350,41 @@ std::vector<Component> ORBPlatformMockImpl::Broadcast_GetComponents(std::string 
 }
 
 /**
- * Select the specified component of the currently tuned broadcast channel.
+ * Override the default component selection of the terminal for the specified type.
  *
- * @param componentType The component type (0: video, 1: audio, 2: subtitle)
- * @param pid           The component's pid used as identifier
+ * The component in the stream that has the specified PID, CTAG (if specified), and language (if
+ * specified) shall be selected. If pidOrSuspended equals 0, no component for the specified type
+ * shall be selected for presentation.
+ *
+ * Default component selection shall be restored for the specified type when
+ * restoreDefaultComponentSelection is called, the channel is changed, the application
+ * terminates, or the user selects a different track of the same type in the terminal UI.
+ *
+ * Security: FOR_BROADCAST_APP_ONLY
+ *
+ * @param componentType  The component type (0: video, 1: audio, 2: subtitle)
+ * @param pidOrSuspended The component PID or 0 to suspend presentation
+ * @param ctag           The component tag or 0 if not specified
+ * @param language       The component language or an empty string if not specified
  */
-void ORBPlatformMockImpl::Broadcast_SelectComponent(int componentType, int pid)
+void ORBPlatformMockImpl::Broadcast_OverrideDefaultComponentSelection(
+   int componentType,
+   int pidOrSuspended,
+   int ctag,
+   std::string language
+   )
 {
-   ORB_LOG("componentType=%d pid=%d", componentType, pid);
+   ORB_LOG("componentType=%d pidOrSuspended=%d", componentType, pidOrSuspended);
    switch (componentType)
    {
       case 0:
-         s_SelectedComponent_Pid_Video = pid;
+         s_SelectedComponent_Pid_Video = pidOrSuspended;
          break;
       case 1:
-         s_SelectedComponent_Pid_Audio = pid;
+         s_SelectedComponent_Pid_Audio = pidOrSuspended;
          break;
       case 2:
-         s_SelectedComponent_Pid_Subtitle = pid;
+         s_SelectedComponent_Pid_Subtitle = pidOrSuspended;
          break;
       default:
          break;
@@ -377,12 +394,15 @@ void ORBPlatformMockImpl::Broadcast_SelectComponent(int componentType, int pid)
 }
 
 /**
- * Unselect any currently selected component of the given type for the
- * currently tuned broadcast channel.
+ * Restore the default component selection of the terminal for the specified type.
  *
- * @param componentType The componentType (0: video, 1: audio, 2: subtitle)
+ * If playback has already started, the presented component shall be updated.
+ *
+ * Security: FOR_BROADCAST_APP_ONLY
+ *
+ * @param componentType The component type (0: video, 1: audio, 2: subtitle)
  */
-void ORBPlatformMockImpl::Broadcast_UnselectComponent(int componentType)
+void ORBPlatformMockImpl::Broadcast_RestoreDefaultComponentSelection(int componentType)
 {
    ORB_LOG("componentType=%d", componentType);
    switch (componentType)

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
@@ -42,8 +42,8 @@ public:
    virtual bool Broadcast_SetChannelToDsd(std::string dsd, int sid, bool trickplay, std::string contentAccessDescriptorURL, bool quiet, Channel::ErrorState *errorState) override;
    virtual std::vector<Programme> Broadcast_GetProgrammes(std::string ccid) override;
    virtual std::vector<Component> Broadcast_GetComponents(std::string ccid, int componentType) override;
-   virtual void Broadcast_SelectComponent(int componentType, int pid) override;
-   virtual void Broadcast_UnselectComponent(int componentType) override;
+   virtual void Broadcast_OverrideDefaultComponentSelection(int componentType, int pidOrSuspended, int ctag, std::string language) override;
+   virtual void Broadcast_RestoreDefaultComponentSelection(int componentType) override;
    virtual void Broadcast_SetPresentationSuspended(bool presentationSuspended) override;
    virtual void Broadcast_Stop() override;
    virtual void Broadcast_Reset() override;

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -281,35 +281,46 @@ hbbtv.bridge.broadcast = (function() {
    }
 
    /**
-    * Select the broadcast component with the given type, PID and optionally language.
-    *
+    * Override the default component selection of the terminal for the specified type.
+    * 
+    * The component in the stream that has the specified PID, CTAG (if specified), and language (if
+    * specified) shall be selected. If pidOrSuspended equals 0, no component for the specified type
+    * shall be selected for presentation.
+    * 
+    * Default component selection shall be restored for the specified type when
+    * restoreDefaultComponentSelection is called, the channel is changed, the application
+    * terminates, or the user selects a different track of the same type in the terminal UI.
+    * 
+    * If playback has already started, the presented component shall be updated.
+    * 
     * Security: FOR_BROADCAST_APP_ONLY.
     *
-    * @param {number} type The type of the component to select (COMPONENT_TYPE_* code).
-    * @param {number} pid The PID of the component to select.
-    * @param {string} language Optionally, the language of the component to select; or an empty
-    *    string otherwise.
+    * @param {number} type Type of component selection to override (COMPONENT_TYPE_* code).
+    * @param {number} pidOrSuspended Component PID or 0 to suspend presentation.
+    * @param {number} ctag Component CTAG or 0 if not specified.
+    * @param {string} language Component language of an empty string if not specified.
     */
-   exported.selectComponent = function(type, pid, language) {
-      hbbtv.native.request("Broadcast.selectComponent", {
+   exported.overrideDefaultComponentSelection = function(type, pidOrSuspended, ctag, language) {
+      hbbtv.native.request("Broadcast.overrideDefaultComponentSelection", {
          type: type,
-         pid: pid,
+         pidOrSuspended: pidOrSuspended,
+         ctag: ctag,
          language: language
       });
    }
-
+   
    /**
-    * Unselect the broadcast component with the given type and PID.
-    *
+    * Restore the default component selection of the terminal for the specified type.
+    * 
+    * If playback has already started, the presented component shall be updated.
+    * 
     * Security: FOR_BROADCAST_APP_ONLY.
     *
-    * @param {number} type The type of the component to unselect (COMPONENT_TYPE_* code).
-    * @param {number} pid The PID of the component to unselect.
+    * @param {number} type Type of component selection to restore (COMPONENT_TYPE_* code).
     */
-   exported.unselectComponent = function(type, pid) {
-      hbbtv.native.request("Broadcast.unselectComponent", {
-         type: type,
-         pid: pid
+   exported.restoreDefaultComponentSelection = function(type) {
+      hbbtv.native.request("Broadcast.restoreDefaultComponentSelection", {
+         type: type
       });
    }
 


### PR DESCRIPTION
Replace selectComponent/unselectComponent in bridge with overrideDefaultComponentSelection/restoreDefaultComponentSelection and delete default property from Component. This change makes it explicit when control of component selection is returned to the terminal, instead of ORB trying to select the default component itself. This change adds CTAG to the method signature, so that it can be used to identify the component, when it is available.