### PR TITLE
hardwareVersion is optional, but the ; after it is mandatory

### DIFF
--- a/android/tvbrowsershell/src/main/java/org/orbtv/tvbrowsershell/MainActivity.java
+++ b/android/tvbrowsershell/src/main/java/org/orbtv/tvbrowsershell/MainActivity.java
@@ -38,7 +38,7 @@ public class MainActivity extends Activity {
    private static final int APP2APP_LOCAL_PORT = 8185;
    private static final int APP2APP_REMOTE_PORT = 8186;
    private static final String MAIN_ACTIVITY_UUID = "abcd-efgh-hijk-lmno";
-   private static final String USER_AGENT = "HbbTV/1.6.1 (+DRM; OBS; Android; v1.0.0-alpha; OBS;)";
+   private static final String USER_AGENT = "HbbTV/1.6.1 (+DRM; OBS; Android; v1.0.0-alpha; ; OBS;)";
    private static final String SANS_SERIF_FONT_FAMILY = "Tiresias Screenfont";
    private static final String FIXED_FONT_FAMILY = "Letter Gothic 12 Pitch";
 

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
@@ -935,7 +935,7 @@ bool ORBPlatformMockImpl::Configuration_RequestAccessToDistinctiveIdentifier(std
 std::string ORBPlatformMockImpl::Configuration_GetUserAgentString()
 {
    ORB_LOG_NO_ARGS();
-   std::string userAgentString = "HbbTV/1.6.1 (; OBS; WPE; v1.0.0-alpha; OBS;)";
+   std::string userAgentString = "HbbTV/1.6.1 (; OBS; WPE; v1.0.0-alpha; ; OBS;)";
    return userAgentString;
 }
 

--- a/rdk/ORBBrowser/WebKitImplementation.cpp
+++ b/rdk/ORBBrowser/WebKitImplementation.cpp
@@ -2599,7 +2599,7 @@ private:
       // The user agent for hbttv string is set here and not in the config file.
       // The reason for this is that When WPEFramework (write_config) identifies a semicolon
       // it creates a json array. Currently there is no way to escape the semicolon character
-      auto ua = WKStringCreateWithUTF8CString("HbbTV/1.6.1 (; OBS; WPE; v1.0.0-alpha; OBS;)");
+      auto ua = WKStringCreateWithUTF8CString("HbbTV/1.6.1 (; OBS; WPE; v1.0.0-alpha; ; OBS;)");
       WKPageSetCustomUserAgent(_page, ua);
       WKRelease(ua);
 


### PR DESCRIPTION
hardwareVersion is optional, but the ; after it is mandatory

HbbTV/1.6.1 (capabilities; vendorName; modelName; softwareVersion; [hardwareVersion]; familyName; reserved)