### PR TITLE
Enable creation of markdown file for ORB.json

### DIFF
--- a/rdk/ORB/service/thunder/jsonrpc/ORB.json
+++ b/rdk/ORB/service/thunder/jsonrpc/ORB.json
@@ -7,10 +7,6 @@
     "class": "ORB",
     "description": "ORB JSON-RPC interface"
   },
-  "common":
-  {
-    "$ref": "common.json"
-  },
   "methods":
   {
     "SendKeyEvent":
@@ -59,7 +55,9 @@
       },
       "result":
       {
-        "$ref": "#/common/results/void"
+        "type": "null",
+        "default": null,
+        "description": "Always null"
       }
     }
   }


### PR DESCRIPTION
common.json needs to be available to create the markdown API documentation file, but it isn't, so remove it and define the return type for SetPreferredUILanguage explicitly