### PR TITLE
Fix content type check in SessionCallbackImpl.cpp for rdk

### DIFF
--- a/rdk/ORB/library/src/core/SessionCallbackImpl.cpp
+++ b/rdk/ORB/library/src/core/SessionCallbackImpl.cpp
@@ -83,7 +83,7 @@ std::string SessionCallbackImpl::GetXmlAitContents(const std::string &url)
         url);
     if (downloadedObject != nullptr)
     {
-        if (downloadedObject->GetContentType().rfind("application/vnd.dvb.ait+xml;", 0) == 0)
+        if (downloadedObject->GetContentType().rfind("application/vnd.dvb.ait+xml", 0) == 0)
         {
             return downloadedObject->GetContent();
         }


### PR DESCRIPTION
Fix for content type checking in RDK that affects org.hbbtv_SMALL_INC0100