### PR TITLE
Fix for org.hbbtv_MDEVSYNC1552

### DIFF
--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/MediaSynchroniserManager.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/MediaSynchroniserManager.java
@@ -104,12 +104,24 @@ class MediaSynchroniserManager {
         long startTime = 0;
         long duration = 0;
         String programmeId = "";
-        if (programmes != null && programmes.size() > 0) {
-            BridgeTypes.Programme programme = programmes.get(0);
-            if (programme != null && programme.programmeId != null && !programme.programmeId.isEmpty()) {
-                programmeId = programme.programmeId.trim();
-                startTime = programme.startTime;
-                duration = programme.duration;
+        String hexOnetId = Integer.toHexString(onetId);
+        String hexTransId = Integer.toHexString(transId);
+        String hexServId = Integer.toHexString(servId);
+        if (programmes != null) {
+            for (BridgeTypes.Programme programme : programmes) {
+                if (programme != null && programme.programmeId != null && !programme.programmeId.isEmpty()) {
+                    String[] ids = programme.programmeId.split(";");
+                    if (ids.length > 0) {
+                        ids = ids[0].replace("dvb://", "").split("\\.");
+                        if (ids.length == 3 && ids[0].equalsIgnoreCase(hexOnetId) &&
+                            ids[1].equalsIgnoreCase(hexTransId) && ids[2].equalsIgnoreCase(hexServId)) {
+                            programmeId = programme.programmeId.trim();
+                            startTime = programme.startTime;
+                            duration = programme.duration;
+                            break;
+                        }
+                    }
+                }
             }
         }
 

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
@@ -440,7 +440,7 @@ class OrbSession implements IOrbSession {
         String ccid = mOrbSessionCallback.getCurrentCcid();
         if (!ccid.isEmpty()) {
             BridgeTypes.Channel channel = mOrbSessionCallback.getChannel(ccid);
-            List<BridgeTypes.Programme> programmes = mOrbSessionCallback.getPresentFollowingProgrammes(ccid);
+            List<BridgeTypes.Programme> programmes = mOrbSessionCallback.getProgrammeList(ccid);
             mMediaSynchroniserManager.updateBroadcastContentStatus(onetId, transId, servId, statusCode, permanentError, programmes);
         }
     }
@@ -455,7 +455,7 @@ class OrbSession implements IOrbSession {
         String ccid = mOrbSessionCallback.getCurrentCcid();
         if (!ccid.isEmpty()) {
             BridgeTypes.Channel channel = mOrbSessionCallback.getChannel(ccid);
-            List<BridgeTypes.Programme> programmes = mOrbSessionCallback.getPresentFollowingProgrammes(ccid);
+            List<BridgeTypes.Programme> programmes = mOrbSessionCallback.getProgrammeList(ccid);
             mMediaSynchroniserManager.updateBroadcastContentStatus(channel.onid, channel.tsid, channel.sid, BridgeTypes.CHANNEL_STATUS_PRESENTING, false, programmes);
         }
     }

--- a/components/network_services/media_synchroniser/media_synchroniser.cpp
+++ b/components/network_services/media_synchroniser/media_synchroniser.cpp
@@ -922,14 +922,27 @@ void MediaSynchroniserManager::updateDvbInfo(const int &onetId, const int &trans
 {
     char uriBuffer[32];
     std::string ciString;
-    if (!programmeId.empty())
+    std::size_t semicolonPos = programmeId.find(';');
+    std::string formattedProgrammeId;
+
+    if (semicolonPos != std::string::npos && semicolonPos + 1 < programmeId.length())
+    {
+        std::string extractedId = programmeId.substr(semicolonPos + 1);
+        char programmeIdBuffer[5];
+        sprintf(programmeIdBuffer, "%04d", std::stoi(extractedId));
+        formattedProgrammeId = programmeIdBuffer;
+    }
+    else
+    {
+        formattedProgrammeId = programmeId;
+    }
+
+    if (!formattedProgrammeId.empty())
     {
         char ciBuffer[512];
-        sprintf(ciBuffer, ";%s~%s--PT%02ldH%02ldM", programmeId.c_str(),
+        sprintf(ciBuffer, ";%s~%s--PT%02ldH%02ldM", formattedProgrammeId.c_str(),
             MediaSynchroniser::GetDvbDateFromTimestamp(startTime).c_str(), duration / 3600,
-            (duration %
-             3600) /
-            60);
+            (duration % 3600) / 60);
         ciString = ciBuffer;
     }
     sprintf(uriBuffer, "dvb://%04x.%04x.%04x", onetId, transId, servId);


### PR DESCRIPTION
Description:
The CSS-CII JSON message does not contain the required EPG metadata. 
onProgrammesChanged event should propagate the event data to MediaSynchronizer. However, getPresentFollowingProgrammes() is empty while getProgrammeList() contains the whole list correctly.

Proposed Changes:
* get the full programme list during programme event change instead of  only the present & following event
* select only the programme events in media sync manager relevant to the current channel during synchronization 
* fix extracting/parsing the event_id from the programmeId when updating content status

Tested:
org.hbbtv_MDEVSYNC1552