### PR TITLE
Enable compatibility mode for 1.1.1 hbbtv apps so VK keys are always available (even when app is not activated)

### DIFF
--- a/components/application_manager/app.cpp
+++ b/components/application_manager/app.cpp
@@ -45,6 +45,7 @@ App App::CreateAppFromAitDesc(const Ait::S_AIT_APP_DESC *desc,
     bool isTrusted)
 {
     App app;
+    app.versionMinor = INT8_MAX;
 
     app.baseUrl = Ait::GetBaseURL(desc, currentService, isNetworkAvailable, &app.protocolId);
 
@@ -62,6 +63,14 @@ App App::CreateAppFromAitDesc(const Ait::S_AIT_APP_DESC *desc,
     app.isServiceBound = desc->appDesc.serviceBound;
     app.isHidden = isBroadcast; // Broadcast-related applications need to call show.
     app.parentalRatings = desc->parentalRatings;
+
+    for (uint8_t i = 0; i < desc->appDesc.appProfiles.size(); i++)
+    {
+        if (app.versionMinor >= desc->appDesc.appProfiles[i].versionMinor)
+        {
+            app.versionMinor = desc->appDesc.appProfiles[i].versionMinor;
+        }
+    }
 
     /* AUTOSTARTED apps are activated when they receive a key event */
     app.isActivated = !(desc->controlCode == Ait::APP_CTL_AUTOSTART);

--- a/components/application_manager/app.h
+++ b/components/application_manager/app.h
@@ -61,6 +61,7 @@ public:
     bool isActivated = true;
     uint16_t id;
     std::vector<Ait::S_APP_PARENTAL_RATING> parentalRatings;
+    uint8_t versionMinor;
 };
 
 #endif // HBBTV_SERVICE_APP_H

--- a/components/application_manager/application_manager.cpp
+++ b/components/application_manager/application_manager.cpp
@@ -258,11 +258,19 @@ uint16_t ApplicationManager::SetKeySetMask(uint16_t appId, uint16_t keySetMask)
         {
             if ((keySetMask & KEY_SET_VCR) != 0)
             {
-                keySetMask &= ~KEY_SET_VCR;
+                // compatibility check for older versions
+                if (m_app.versionMinor > 1)
+                {
+                    keySetMask &= ~KEY_SET_VCR;
+                }
             }
             if ((keySetMask & KEY_SET_NUMERIC) != 0)
             {
-                keySetMask &= ~KEY_SET_NUMERIC;
+                // compatibility check for older versions
+                if (m_app.versionMinor > 1)
+                {
+                    keySetMask &= ~KEY_SET_NUMERIC;
+                }
             }
         }
         m_app.keySetMask = keySetMask;


### PR DESCRIPTION
Description:

- KEYREQCON0XXX hbbtv tests are broadcast-related (autostart) applications which request various VK_X keys before the app is activated. The request, depending on the type of key, is to be allowed/refused based on the availability column of table 12 (section 10.2.2.1)

- older org.hbbtv_00000XXX hbbtv tests are broadcast-related (autostart) applications which always expect the VK_X keys to be available. These applications reference HBBTV - 1.1.1, which did not implement conditional access to VK_XX keys until the second erratum of HBBTV 1.2.1

Proposed Change:
Add a member in app class to populate the minor application version from the ait table in order for the application manager to understand the difference & enable/disable clearing the key mask depending on this version.

Tested on:

org.hbbtv_00000580
org.hbbtv_00000590
org.hbbtv_00000600
org.hbbtv_00000610
org.hbbtv_00000620
org.hbbtv_00000730
org.hbbtv_00000740
org.hbbtv_00000750
org.hbbtv_00000760
org.hbbtv_00000770
org.hbbtv_KEYREQCON0600
