### PR TITLE
Change dash option to not drop the video buffer while changing resolutions.

### DIFF
--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -646,7 +646,7 @@ hbbtv.objects.DashProxy = (function() {
                 streaming: {
                     trackSwitchMode: {
                         audio: 'alwaysReplace',
-                        video: 'alwaysReplace',
+                        video: 'neverReplace',
                     },
                     capabilities: {
                         filterUnsupportedEssentialProperties: true,


### PR DESCRIPTION
Description:
During resolution (quality) changes, (not) replacing the video buffers can introduce visual artifacts (black frame). Depending on the changed quality and the general performance of the terminal, this black frame can appear for more msecs. Keeping the buffers for more time can possibly make the transitions appear smoother.   

Proposed Change:
Change video track switch mode in dash proxy 
back to default 'neverReplace' configuration.

Tested on:
com.eurofins_UHD-ADAPTATION-1060

