### PR TITLE
Org.hbbtv dash errorhandle0009

### DIFF
--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -666,6 +666,8 @@ hbbtv.objects.DashProxy = (function() {
                     },
                     utcSynchronization: {
                         enableBackgroundSyncAfterSegmentDownloadError: true,
+                        backgroundAttempts: 1,
+                        timeBetweenSyncAttempts: 5,
                     },
                 },
                 errors: {


### PR DESCRIPTION
org.hbbtv_DASH-ERRORHANDLE0010: Do only one time sync after reloading the manifest on segment error
org.hbbtv_DASH-ERRORHANDLE0009: Allow a retry when we get a network error for a segment

