### PR TITLE
Add support for default audio language based on user preferences.

### DIFF
--- a/BuildPolyfill.mk
+++ b/BuildPolyfill.mk
@@ -2,6 +2,7 @@ define build-polyfill
 $(eval polyfill_iframe_srcs = \
 src/housekeeping/banner.js \
 src/housekeeping/beginiffe.js \
+src/languagecodes.js \
 src/mediaproxies/init.js \
 src/natives/$(3).js \
 src/mediaproxies/tracklists/audiotracklist.js \

--- a/src/housekeeping/beginiffe.js
+++ b/src/housekeeping/beginiffe.js
@@ -4,3 +4,5 @@
         let hbbtv = {};
 
         const __URL = URL;
+
+        

--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -24,6 +24,13 @@ hbbtv.mediaManager = (function() {
             }).result, 
     };
 
+    hbbtv.bridge = {
+        configuration: {
+            getPreferredAudioLanguage: () =>
+            hbbtv.native.request('Configuration.getPreferredAudioLanguage').result
+        }
+    };
+
     function initialise() {
         addSourceManipulationIntercept();
         addMutationIntercept();


### PR DESCRIPTION
Description:
Video playback does not take into account (user's) language preferences as it selects the first available audio track.
(This applies only during first playback)

Proposed Changes
Use the configuration hbbtv object to retrieve the languages preferences and select the relevant audio track.
Νοtice that due to iframe sandboxing we need to expose the request in mediamanager.js.
Works for both MP4 and DASH (html5 video). A/V control object already supports this.

Tested on:
org.hbbtv_HTML50160
org.hbbtv_HTML50165

