### PR TITLE
fix typo which resulted in not sending the correct av control object state when paused

### DIFF
--- a/src/objects/avcontrol.js
+++ b/src/objects/avcontrol.js
@@ -247,7 +247,7 @@ hbbtv.objects.AVControl = (function() {
                     // here, because we are in rewind mode or stopped, the videoElement is already
                     // in paused state, and because of that the event listener will not
                     // be triggered, so we call explicitly transitionToState.call(thiz, PLAY_STATE_PAUSED);
-                    transitionToState.call(thiz, PLAY_STATE_PAUSED);
+                    transitionToState.call(this, PLAY_STATE_PAUSED);
                 }
                 else {
                     priv.onPauseHandler();


### PR DESCRIPTION
Description:
A/V control object can not transition to pause state

Proposed changes:
fix typo

Regression testing:
org.hbbtv_MEDIAPLAYER0010
org.hbbtv_MEDIAPLAYER0020
org.hbbtv_MEDIAPLAYER0180
tv.oipf_DAE-MEDIA_PLAYBACK-007-001
org.hbbtv_00003630
org.hbbtv_00003650
org.hbbtv_00003670
org.hbbtv_00003680
org.hbbtv_00003700
tv.oipf_DAE-MEDIA_PLAYBACK-007-003