### PR TITLE
On external channel change (e.g., CH+), VBOs linked through bindToCur…

### DIFF
--- a/src/objects/videobroadcast.js
+++ b/src/objects/videobroadcast.js
@@ -1578,6 +1578,30 @@ hbbtv.objects.VideoBroadcast = (function() {
                     unregisterAllStreamEventListeners(p);
                     p.playState = PLAY_STATE_UNREALIZED;
                     dispatchPlayStateChangeEvent.call(this, p.playState);
+                } else if (p.playState == PLAY_STATE_STOPPED) {
+                    // The VBO is stopped and the channel is changed externally (e.g., ch+)
+                    if (event.statusCode == CHANNEL_STATUS_CONNECTING) {
+                        if (
+                            p.currentChannelData != null &&
+                            (event.servId != p.currentChannelData.sid ||
+                            event.onetId != p.currentChannelData.onid ||
+                            event.transId != p.currentChannelData.tsid)
+                        ) {
+                            try {
+                                p.currentChannelData = hbbtv.objects.createChannel(
+                                    hbbtv.bridge.broadcast.getCurrentChannelForEvent()
+                                );
+                                p.playState = PLAY_STATE_CONNECTING;
+                                dispatchChannelChangeSucceededEvent.call(
+                                    this,
+                                    p.currentChannelData
+                                );
+                                dispatchPlayStateChangeEvent.call(this, p.playState);
+                            } catch (e) {
+                                // Ignored
+                            }
+                        }
+                    }
                 } else {
                     console.log(
                         'Unhandled state transition. Current playState ' + p.playState + ', event:'


### PR DESCRIPTION
…rentChannel() must undergo the same state transitions and dispatch identical events as if setChannel() was used (see A.2.4.1). However, this wasn’t happening in the stopped state as we removed the bridge event listeners.