### PR TITLE
Fix regression issues for various dash error handle hbbtv tests

### DIFF
--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -670,7 +670,7 @@ hbbtv.objects.DashProxy = (function() {
                     },
                     retryAttempts: {
                         MPD: 0,
-                        MediaSegment: 1,
+                        MediaSegment: 0,
                         InitializationSegment: 0,
                         BitstreamSwitchingSegment: 0,
                         IndexSegment: 0,


### PR DESCRIPTION
Fixed regression for the following tests:
org.hbbtv_DASH-ERRORHANDLE0009
org.hbbtv_DASH-ERRORHANDLE0011
org.hbbtv_DASH-ERRORHANDLE0015
org.hbbtv_DASH-ERRORHANDLE0041
org.hbbtv_DASH-ERRORHANDLE0042
org.hbbtv_DASH-ERRORHANDLE0044
org.hbbtv_DASH-ERRORHANDLE0050