### PR TITLE
Update license to Apache License 2.0 for orb project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,50 +1,203 @@
-If You or the organisation You work for has signed a licence with Ocean Blue Software Ltd for the ORB Software then the ORB licence below does not apply to your use of the ORB Software.
 
-In all other cases Your use of the ORB software is governed by the ORB Licence below
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-ORB Licence
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-This Licence applies to all software available as part of the Open Red Button Project (ORB) in its entirety or in part, which will be referred to as "ORB Software" in this document. ORB Software will be clearly identified in the copyright message in each file. The term "ORB Software" as used below means either the ORB software or any derivative work under copyright law; that is a work containing ORB Software or part of it, either Verbatim or with modifications and/or translated into another programming language. Hereafter, translation is included without limitation in the term "modification".
+   1. Definitions.
 
-"Source Code" means the preferred form of the ORB Software for making modifications to it including the complete source code for all modules in whatever programming language they are supplied, plus any associated interface definition files, data tables, scripts and documentation.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Activities other than copying, distribution and modification are outside of the scope of this License. The act of running a program using ORB software is not restricted.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-Certain rights under this agreement are only available to a "Contributor" to or "Supporter" of ORB as defined on the ORB website (www.orb-tv.org). You are required to refer to www.orb-tv.org to establish whether any particular entity is a Contributor on the actual date of the first relevant transaction and quarterly thereafter. You should not accept any other form of evidence that an entity is a Contributor or Supporter on that date and should keep appropriate records. You will not be held liable for any inaccuracy of data provided directly by the ORB Project.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-Certain rights under this agreement such as compilation, linking to, distribution or copying are only valid when the ORB Software is used having been 'Targeted' at certain 'Platforms'. A Platform is a semiconductor product which includes the processor on which the ORB Software will run. Targeting includes but is not limited to building or compilation to run on a target Platform, linking to software provided with a target Platform or any such action which enables the ORB Software to run on a Platform. 
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-Each licensee is referred to as "you" in this document.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-1. You may copy and distribute exact copies of ORB Software in Source Code form to any third party who is at the time of transfer a Contributor or Supporter of ORB provided that you also are a Contributor or Supporter of ORB; you keep intact all notices; copyright messages and disclaimer of warranty and you include a copy of this licence with the ORB Software.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-2. You may modify your copy or copies of the ORB Software or any portion of it, thus forming a work based on the ORB Software (which hereafter is included in the term ORB Software) and distribute as Source Code such modifications or work under the terms set forth in Section 1 above, provided that you keep intact all notices, copyright messages and disclaimer of warranty; you include a copy of this licence in the distribution and that you add a prominent notice stating that you changed the files, the nature of change and the date of the change. 
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-You agree that the modified work is licenced at no charge. However, if substantial identifiable sections of that work are not derived from the ORB Software and can reasonably considered independent and separate works you are free to set whatever terms you see fit for those separate works. 
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-3. If you are a Contributor, you may copy and distribute a Binary version (including any header files or scripts which are required only for the purposes of linking this binary version to other software) to a third party organisation or person so long as this is only as part of your product, you keep intact all notices, copyright messages and disclaimer of warranty in any human readable files and you include a copy of this licence agreements in the distribution. If you are a Supporter, you have no rights to distribute the ORB Software in any form apart from to another Contributor or Supporter, and any attempt to do so will automatically terminate your rights under this Licence Agreement.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-4. If you are a Contributor you are permitted to share the ORB Software with your contractors or companies performing software development on your behalf, provided that this is for no longer than is required, all copies are deleted immediately that the contractor is no longer working for you on the ORB Software and that the contractor only uses the ORB Software in relation to their work for you. You are responsible for ensuring that the contractor complies with this licence and your licence will automatically terminate in the event that your subcontractor violates the terms of this Licence, unless the ORB project decides to the contrary.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-5. If you receive the ORB Software in source code form and you are not a Contributor or Supporter you must either immediately become an ORB Supporter or Contributor or destroy the ORB Software you have received.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-6. If your rights under this licence are automatically terminated then your status (if any) as a Contributor or Supporter of ORB will terminated as well.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-7. You may target/compile the ORB Software to run on a PC only for the purposes of running or extending the ORB Test Suite, performing development, and providing demonstrations. You may not distribute this PC version for any reason other than specified here.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-8. You may not copy, modify, sublicense, link with or distribute the ORB Software except as expressly provided under this Licence Agreement. Any such attempt to copy, modify, sublicense, link with or distribute the ORB Software is void and will automatically terminate your rights under this Licence, unless the ORB project decides to the contrary. However, parties who have received copies or rights from you under this licence will not have their licences terminated so long as such parties remain in full compliance.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-9. If you fix bugs in the ORB Software you are required to offer these bugs fixes to the ORB Project, using the process defined on the ORB website. The ORB Project is not required to accept these fixes. Any fixes offered must be licenced using this licence and you must ensure that the fix does not infringe the rights of any third party. If you extend the functionality of the ORB Software you may offer these extensions to the ORB Project but you are not required to do so.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-10. You are not required to accept this licence agreement, since you have not signed it. However, nothing else grants you permission to modify, compile, link to, copy or distribute the ORB Software. These actions are prohibited by law if you do not accept this licence. Therefore, by modifying, compiling, linking to, copying, or distributing the ORB Software, you indicate your acceptance of this License to do so, and all its terms and conditions.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-11. Each time you redistribute the ORB Software as source code, the recipient automatically receives a licence from ORB subject to these terms and conditions. You may not impose any further restrictions on the recipient's exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this Licence. 
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-12. You may have received a copy of the ORB Software for evaluation purposes. If this is the case then the copy you received will include an evaluation.txt file, which will define person/organisation permitted to perform the evaluation and the term of that evaluation. For the term and provided you are the person/an employee of the organisation defined then you will be treated as a Supporter for purposes of this licence. At the end of the term you must either become a Contributor or a Supporter of the ORB Project. If you do not then all rights under this licence will terminate and all copies of the ORB Software must be immediately destroyed. In the absence of an evaluation.txt file or if you have received a copy of the ORB Software with an evaluation.txt file but are not the person/employee of the organisation defined then you have no additional rights under this licence. If you distribute the ORB Software under this licence then you must remove the evaluation.txt file before doing so. You may not modify the evaluation.txt file.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-13. If any portion of this licence is held invalid or unenforceable under any circumstance, the balance will apply, and the whole is intended to apply in other circumstances.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-14. Because the ORB Software is licenced free of charge there is no warranty for the ORB Software, to the extent permitted by applicable law. Except when otherwise stated in writing the copyright holders and/or other parties provide the ORB Software "as is" without warranty of any kind, either expressed or implied, including, but not limited to implied warranties of merchantability and fitness for a particular purpose. The entire risk as to the quality and performance of the ORB Software is with you. Should the ORB Software prove defective you assume the cost of all necessary servicing repair or correction.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-15. In no event unless required by applicable law or agreed to in writing will any copyright holder or any other party who may modify, copy or distribute the ORB Software as permitted above be liable to you for damages, including any general, special, incidental or consequential damages arising out of the use or inability to use the ORB Software (including but not limited to loss of data or data being rendered inaccurate or losses sustained by you or third parties or a failure of the ORB Software to operate with any other software), even if such holder or other party has been advised of the possibility of such damages.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 

--- a/README.md
+++ b/README.md
@@ -2,42 +2,49 @@
 
 # The Open Red Button Project
 
-The Open Red Button Project is a cross-browser solution for HbbTV.
+## Project Overview
 
-It is a collection of components that implement the extensions required to support HbbTV applications in a browser:
+The Open Red Button Project (ORB) is a cross-platform solution that extends a range of browsers with HbbTV support. Utilising JavaScript and C++ components, ORB extends browser capabilities and integrates seamlessly with Android's WebView and RDK's WPE. This makes it easier for developers to add HbbTV features to these platforms.
 
-* [src/](src/) JavaScript polyfill.
+Designed as a reference implementation, ORB facilitates integration but may need modifications, like minor browser patches, for actual product application. Ocean Blue Software (OBS), creators of ORB, specialise in customising ORB for real-world usage. **For commercial support and to discuss how OBS can assist your project, contact OBS at [info@oceanbluesoftware.co.uk](mailto:info@oceanbluesoftware.co.uk).**
 
-* [components/](components/) Application manager and network services native libraries.
+## Overview
 
-### Libraries
+* **[src/:](src/)** Common polyfill adding HbbTV APIs to the browser (JavaScript).
 
-For convenience on some systems we package the components as libraries to help with the integration:
+* **[components/:](components/)** Application Manager and Network Services components, including Media Synchronization and Companion Screen (C++).
 
-* [android/](android/) Android library and test shell that uses the system WebView.
+* **[android/](android/):** Android library utilising the system WebView and a mock application for integration testing.
 
-* [rdk/](rdk/) RDK library.
+* **[rdk/](rdk/):** RDK library utilising the system WPE browser.
 
 See those directories for specific build and integration information.
 
-## Resources
+## Contribute
 
-[ORB Contributors JavaScript Guide](https://docs.google.com/document/d/1s3sOCIP6_o7o9Uk1UzWZLO7NYSQ3uRqeytzSgjPZiDE/)
-
-## How to contribute
-
-If you are not otherwise coordinated with the project, raise an [Issue](https://github.com/OpenRedButtonProject/Orb/issues) before starting work on a new fix or feature to avoid duplicated effort.
+If you are not otherwise coordinated with the project, raise a [new issue](https://github.com/OpenRedButtonProject/Orb/issues) before starting work on a new fix or feature to avoid duplicated effort.
 
 1. Create or update your fork of the repository to work in.
 2. Create a new topic branch on master and complete the fix or feature.
-3. Open a pull request. You may find upstream master has changed and you need to rebase your branch.
+3. Open a pull request. You may find that upstream master has changed and you need to rebase your branch.
 
 The maintainer will squash and merge your branch if it is accepted or they will comment on the pull request.
 
-Contributions to ORB Software must be licensed under the ORB License that can be found in the [LICENSE](LICENSE) file at the top level of this repository.
+### Licensing
+
+By contributing to the ORB project, you agree to license your contributions under the Apache License 2.0.
+
+### Resources
+
+* **[ORB C++ Contributors Guide:](https://docs.google.com/document/d/13p6xlcCEkHy__YcaARlAoBQlYd7wqlK4wuEdK13HFds/edit#heading=h.udkzp62bhb46)** Guide for using C++ with ORB.
+
+* **[ORB JS Contributors Guide:](https://docs.google.com/document/d/1OD_ef2eRkz5zv0s7zxmEeH7byhfzPerCL2KPecoTgiQ/edit#heading=h.yfs4lfa8guly)** Guide for using JS with ORB.
 
 ## License
-Software identified as ORB Software in the copyright message in each file is licensed under the ORB License that can be found in the [LICENSE](LICENSE) file at the top level of this repository.
 
-Third-party software is licensed under its respective license, see: [ORB Software Licenses Used](https://docs.google.com/spreadsheets/d/1EuSlycGPBrmEw95TKbG6eeVBz1pkjQXIpYR6IvluAP8/).
+The software designated as ORB Software, as indicated in the copyright notice within each file, is licensed under the Apache License, Version 2.0 (the "License"). You can find the full text of the Apache 2.0 License in the [LICENSE](LICENSE) file located in the root directory of this repository.
+
+### Third-Party Code
+
+The ORB project includes third-party code, each subject to its respective open-source license. This encompasses both external dependencies used in our project and code that we have incorporated directly into our repository. The incorporated code, which may be modified, is also used under the terms of its original license. For information about the specific licenses of the third-party code used in the ORB project, refer to our [Third-Party License Documentation](https://docs.google.com/spreadsheets/d/1EuSlycGPBrmEw95TKbG6eeVBz1pkjQXIpYR6IvluAP8/).
 

--- a/android/mockdialservice/src/main/cpp/jni_utils.cpp
+++ b/android/mockdialservice/src/main/cpp/jni_utils.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "jni_utils.h"

--- a/android/mockdialservice/src/main/cpp/jni_utils.h
+++ b/android/mockdialservice/src/main/cpp/jni_utils.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef HBBTVBROWSER_JNI_UTILS_H

--- a/android/mockdialservice/src/main/cpp/mock_dial_service_native.cpp
+++ b/android/mockdialservice/src/main/cpp/mock_dial_service_native.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <cstdio>

--- a/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/Database.java
+++ b/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/Database.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.mockorbapp;

--- a/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MainActivity.java
+++ b/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MainActivity.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.mockorbapp;

--- a/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MockAit.java
+++ b/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MockAit.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.mockorbapp;

--- a/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MockHttpServer.java
+++ b/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MockHttpServer.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.mockorbapp;

--- a/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MockOrbSessionCallback.java
+++ b/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MockOrbSessionCallback.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.mockorbapp;

--- a/android/orblibrary/src/main/cpp/application_manager_native.cpp
+++ b/android/orblibrary/src/main/cpp/application_manager_native.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "application_manager_native.h"

--- a/android/orblibrary/src/main/cpp/application_manager_native.h
+++ b/android/orblibrary/src/main/cpp/application_manager_native.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef ORB_APPLICATION_MANAGER_NATIVE_H

--- a/android/orblibrary/src/main/cpp/jni_utils.cpp
+++ b/android/orblibrary/src/main/cpp/jni_utils.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "jni_utils.h"

--- a/android/orblibrary/src/main/cpp/jni_utils.h
+++ b/android/orblibrary/src/main/cpp/jni_utils.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef HBBTVBROWSER_JNI_UTILS_H

--- a/android/orblibrary/src/main/cpp/native.cpp
+++ b/android/orblibrary/src/main/cpp/native.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <jni.h>

--- a/android/orblibrary/src/main/cpp/network_services_native.cpp
+++ b/android/orblibrary/src/main/cpp/network_services_native.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "network_services_native.h"

--- a/android/orblibrary/src/main/cpp/network_services_native.h
+++ b/android/orblibrary/src/main/cpp/network_services_native.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef ORB_NETWORK_SERVICES_NATIVE_H

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/App2AppService.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/App2AppService.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/ApplicationManager.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/ApplicationManager.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at the top level of this
- * repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/BrowserView.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/BrowserView.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/DsmccClient.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/DsmccClient.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at the top level of this
- * repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/DvbInputStream.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/DvbInputStream.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at the top level of this
- * repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/HtmlBuilder.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/HtmlBuilder.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSessionCallback.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSessionCallback.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/InjectionInputStream.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/InjectionInputStream.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/MediaSynchroniserManager.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/MediaSynchroniserManager.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSessionFactory.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSessionFactory.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/WebResourceClient.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/WebResourceClient.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orblibrary;

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orbpolyfill;

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeToken.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeToken.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orbpolyfill;

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeTypes.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeTypes.java
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  * <p>
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.orbtv.orbpolyfill;

--- a/components/application_manager/ait.cpp
+++ b/components/application_manager/ait.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * AIT parsing
  *

--- a/components/application_manager/ait.h
+++ b/components/application_manager/ait.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * AIT parsing
  *

--- a/components/application_manager/app.cpp
+++ b/components/application_manager/app.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * App model
  *

--- a/components/application_manager/app.h
+++ b/components/application_manager/app.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * App model
  *

--- a/components/application_manager/application_manager.cpp
+++ b/components/application_manager/application_manager.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * Application manager
  *

--- a/components/application_manager/application_manager.h
+++ b/components/application_manager/application_manager.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * Application manager
  *

--- a/components/application_manager/log.h
+++ b/components/application_manager/log.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * General logging for each supported platform
  *

--- a/components/application_manager/utils.cpp
+++ b/components/application_manager/utils.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * General utilities class
  *

--- a/components/application_manager/utils.h
+++ b/components/application_manager/utils.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * General utilities class
  *

--- a/components/application_manager/xml_parser.cpp
+++ b/components/application_manager/xml_parser.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * XML parser for AIT and DSM-CC
  *

--- a/components/application_manager/xml_parser.h
+++ b/components/application_manager/xml_parser.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * XML parser for AIT and DSM-CC
  *

--- a/components/network_services/UdpSocketService.cpp
+++ b/components/network_services/UdpSocketService.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "UdpSocketService.h"

--- a/components/network_services/UdpSocketService.h
+++ b/components/network_services/UdpSocketService.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef WIP_DVBCSS_HBBTV_UDPSOCKETSERVICE_H

--- a/components/network_services/app2app/app2app_local_service.cpp
+++ b/components/network_services/app2app/app2app_local_service.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "app2app_local_service.h"

--- a/components/network_services/app2app/app2app_local_service.h
+++ b/components/network_services/app2app/app2app_local_service.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef OBS_NS_APP2APP_LOCAL_SERVICE_

--- a/components/network_services/app2app/app2app_remote_service.cpp
+++ b/components/network_services/app2app/app2app_remote_service.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "app2app_remote_service.h"

--- a/components/network_services/app2app/app2app_remote_service.h
+++ b/components/network_services/app2app/app2app_remote_service.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef OBS_NS_APP2APP_REMOTE_SERVICE_

--- a/components/network_services/app2app/log.h
+++ b/components/network_services/app2app/log.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __MANAGER_LOG_H

--- a/components/network_services/media_synchroniser/CSSUtilities.cpp
+++ b/components/network_services/media_synchroniser/CSSUtilities.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/CSSUtilities.h
+++ b/components/network_services/media_synchroniser/CSSUtilities.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/ClockBase.cpp
+++ b/components/network_services/media_synchroniser/ClockBase.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/ClockBase.h
+++ b/components/network_services/media_synchroniser/ClockBase.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/ClockUtilities.cpp
+++ b/components/network_services/media_synchroniser/ClockUtilities.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/ClockUtilities.h
+++ b/components/network_services/media_synchroniser/ClockUtilities.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/ContentIdentificationService.cpp
+++ b/components/network_services/media_synchroniser/ContentIdentificationService.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/ContentIdentificationService.h
+++ b/components/network_services/media_synchroniser/ContentIdentificationService.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/CorrelatedClock.cpp
+++ b/components/network_services/media_synchroniser/CorrelatedClock.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/CorrelatedClock.h
+++ b/components/network_services/media_synchroniser/CorrelatedClock.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/Correlation.cpp
+++ b/components/network_services/media_synchroniser/Correlation.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/Correlation.h
+++ b/components/network_services/media_synchroniser/Correlation.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/Nullable.h
+++ b/components/network_services/media_synchroniser/Nullable.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/SysClock.cpp
+++ b/components/network_services/media_synchroniser/SysClock.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/SysClock.h
+++ b/components/network_services/media_synchroniser/SysClock.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/TimelineSyncService.cpp
+++ b/components/network_services/media_synchroniser/TimelineSyncService.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/TimelineSyncService.h
+++ b/components/network_services/media_synchroniser/TimelineSyncService.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/WallClockService.cpp
+++ b/components/network_services/media_synchroniser/WallClockService.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/WallClockService.h
+++ b/components/network_services/media_synchroniser/WallClockService.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/log.h
+++ b/components/network_services/media_synchroniser/log.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __MANAGER_LOG_H

--- a/components/network_services/media_synchroniser/media_synchroniser.cpp
+++ b/components/network_services/media_synchroniser/media_synchroniser.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/media_synchroniser/media_synchroniser.h
+++ b/components/network_services/media_synchroniser/media_synchroniser.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * NOTICE: This file has been created by Ocean Blue Software and is based on
  * the original work (https://github.com/bbc/pydvbcss) of the British

--- a/components/network_services/service_manager.cpp
+++ b/components/network_services/service_manager.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "service_manager.h"

--- a/components/network_services/service_manager.h
+++ b/components/network_services/service_manager.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef OBS_NS_SERVICE_MANAGER_

--- a/components/network_services/websocket_service.cpp
+++ b/components/network_services/websocket_service.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 

--- a/components/network_services/websocket_service.h
+++ b/components/network_services/websocket_service.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef OBS_NS_WEBSOCKET_SERVICE_

--- a/rdk/ORB/CMakeLists.txt
+++ b/rdk/ORB/CMakeLists.txt
@@ -1,8 +1,17 @@
 ##
 # ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
 #
-# Licensed under the ORB License that can be found in the LICENSE file at
-# the top level of this repository.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 cmake_minimum_required(VERSION 2.8)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/rdk/ORB/library/CMakeLists.txt
+++ b/rdk/ORB/library/CMakeLists.txt
@@ -1,8 +1,17 @@
 ##
 # ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
 #
-# Licensed under the ORB License that can be found in the LICENSE file at
-# the top level of this repository.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 cmake_minimum_required(VERSION 2.8)
 

--- a/rdk/ORB/library/src/core/ORBEngine.cpp
+++ b/rdk/ORB/library/src/core/ORBEngine.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "ORBEngine.h"
 #include "ORBPlatformLoader.h"

--- a/rdk/ORB/library/src/core/ORBEngine.h
+++ b/rdk/ORB/library/src/core/ORBEngine.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORB/library/src/core/ORBEventListener.h
+++ b/rdk/ORB/library/src/core/ORBEventListener.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORB/library/src/core/ORBGenericClient.h
+++ b/rdk/ORB/library/src/core/ORBGenericClient.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORB/library/src/core/ORBPlatformEventHandlerImpl.cpp
+++ b/rdk/ORB/library/src/core/ORBPlatformEventHandlerImpl.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBPlatformEventHandlerImpl.h"

--- a/rdk/ORB/library/src/core/ORBPlatformLoader.cpp
+++ b/rdk/ORB/library/src/core/ORBPlatformLoader.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBPlatformLoader.h"

--- a/rdk/ORB/library/src/core/ORBPlatformLoader.h
+++ b/rdk/ORB/library/src/core/ORBPlatformLoader.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/SessionCallbackImpl.cpp
+++ b/rdk/ORB/library/src/core/SessionCallbackImpl.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "SessionCallbackImpl.h"

--- a/rdk/ORB/library/src/core/SessionCallbackImpl.h
+++ b/rdk/ORB/library/src/core/SessionCallbackImpl.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/api/ORBBrowserApi.h
+++ b/rdk/ORB/library/src/core/api/ORBBrowserApi.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORB/library/src/core/dataTypes/URI.cpp
+++ b/rdk/ORB/library/src/core/dataTypes/URI.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "URI.h"

--- a/rdk/ORB/library/src/core/dataTypes/URI.h
+++ b/rdk/ORB/library/src/core/dataTypes/URI.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/requestHandlers/BroadcastRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/BroadcastRequestHandler.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "BroadcastRequestHandler.h"

--- a/rdk/ORB/library/src/core/requestHandlers/BroadcastRequestHandler.h
+++ b/rdk/ORB/library/src/core/requestHandlers/BroadcastRequestHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/requestHandlers/ConfigurationRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/ConfigurationRequestHandler.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ConfigurationRequestHandler.h"

--- a/rdk/ORB/library/src/core/requestHandlers/ConfigurationRequestHandler.h
+++ b/rdk/ORB/library/src/core/requestHandlers/ConfigurationRequestHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/requestHandlers/DrmRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/DrmRequestHandler.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "DrmRequestHandler.h"
 #include "ORBEngine.h"

--- a/rdk/ORB/library/src/core/requestHandlers/DrmRequestHandler.h
+++ b/rdk/ORB/library/src/core/requestHandlers/DrmRequestHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/requestHandlers/ManagerRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/ManagerRequestHandler.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ManagerRequestHandler.h"

--- a/rdk/ORB/library/src/core/requestHandlers/ManagerRequestHandler.h
+++ b/rdk/ORB/library/src/core/requestHandlers/ManagerRequestHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/requestHandlers/NetworkRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/NetworkRequestHandler.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "NetworkRequestHandler.h"
 

--- a/rdk/ORB/library/src/core/requestHandlers/NetworkRequestHandler.h
+++ b/rdk/ORB/library/src/core/requestHandlers/NetworkRequestHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/requestHandlers/ORBBridgeRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/ORBBridgeRequestHandler.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "ORBBridgeRequestHandler.h"
 #include "BroadcastRequestHandler.h"

--- a/rdk/ORB/library/src/core/requestHandlers/ORBBridgeRequestHandler.h
+++ b/rdk/ORB/library/src/core/requestHandlers/ORBBridgeRequestHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/requestHandlers/ParentalControlRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/ParentalControlRequestHandler.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ParentalControlRequestHandler.h"

--- a/rdk/ORB/library/src/core/requestHandlers/ParentalControlRequestHandler.h
+++ b/rdk/ORB/library/src/core/requestHandlers/ParentalControlRequestHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/requestHandlers/ProgrammeRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/ProgrammeRequestHandler.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ProgrammeRequestHandler.h"

--- a/rdk/ORB/library/src/core/requestHandlers/ProgrammeRequestHandler.h
+++ b/rdk/ORB/library/src/core/requestHandlers/ProgrammeRequestHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/utilities/HttpDownloader.cpp
+++ b/rdk/ORB/library/src/core/utilities/HttpDownloader.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "HttpDownloader.h"

--- a/rdk/ORB/library/src/core/utilities/HttpDownloader.h
+++ b/rdk/ORB/library/src/core/utilities/HttpDownloader.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/utilities/JsonUtil.cpp
+++ b/rdk/ORB/library/src/core/utilities/JsonUtil.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "JsonUtil.h"
 

--- a/rdk/ORB/library/src/core/utilities/JsonUtil.h
+++ b/rdk/ORB/library/src/core/utilities/JsonUtil.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/utilities/MetadataSearchTask.cpp
+++ b/rdk/ORB/library/src/core/utilities/MetadataSearchTask.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "MetadataSearchTask.h"

--- a/rdk/ORB/library/src/core/utilities/MetadataSearchTask.h
+++ b/rdk/ORB/library/src/core/utilities/MetadataSearchTask.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/utilities/ORBLogging.h
+++ b/rdk/ORB/library/src/core/utilities/ORBLogging.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #ifndef __ORB_LOGGING_H__
 #define __ORB_LOGGING_H__

--- a/rdk/ORB/library/src/core/utilities/Query.cpp
+++ b/rdk/ORB/library/src/core/utilities/Query.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBLogging.h"

--- a/rdk/ORB/library/src/core/utilities/Query.h
+++ b/rdk/ORB/library/src/core/utilities/Query.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/core/utilities/SHA256.cpp
+++ b/rdk/ORB/library/src/core/utilities/SHA256.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "SHA256.h"

--- a/rdk/ORB/library/src/core/utilities/SHA256.h
+++ b/rdk/ORB/library/src/core/utilities/SHA256.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORB/library/src/core/utilities/TokenManager.cpp
+++ b/rdk/ORB/library/src/core/utilities/TokenManager.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "TokenManager.h"

--- a/rdk/ORB/library/src/core/utilities/TokenManager.h
+++ b/rdk/ORB/library/src/core/utilities/TokenManager.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/platform/ORBPlatform.h
+++ b/rdk/ORB/library/src/platform/ORBPlatform.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef ORB_PLATFORM_H

--- a/rdk/ORB/library/src/platform/ORBPlatformEventHandler.h
+++ b/rdk/ORB/library/src/platform/ORBPlatformEventHandler.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORB/library/src/platform/dataTypes/Capabilities.h
+++ b/rdk/ORB/library/src/platform/dataTypes/Capabilities.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORB/library/src/platform/dataTypes/Channel.h
+++ b/rdk/ORB/library/src/platform/dataTypes/Channel.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/platform/dataTypes/Component.h
+++ b/rdk/ORB/library/src/platform/dataTypes/Component.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/platform/dataTypes/DisplayInfo.h
+++ b/rdk/ORB/library/src/platform/dataTypes/DisplayInfo.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/platform/dataTypes/DrmSystemStatus.h
+++ b/rdk/ORB/library/src/platform/dataTypes/DrmSystemStatus.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/platform/dataTypes/LocalSystem.h
+++ b/rdk/ORB/library/src/platform/dataTypes/LocalSystem.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/platform/dataTypes/ParentalRating.h
+++ b/rdk/ORB/library/src/platform/dataTypes/ParentalRating.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/library/src/platform/dataTypes/Programme.h
+++ b/rdk/ORB/library/src/platform/dataTypes/Programme.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/platform-mock/CMakeLists.txt
+++ b/rdk/ORB/platform-mock/CMakeLists.txt
@@ -1,8 +1,17 @@
 ##
 # ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
 #
-# Licensed under the ORB License that can be found in the LICENSE file at
-# the top level of this repository.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 cmake_minimum_required(VERSION 2.8)
 

--- a/rdk/ORB/platform-mock/src/DVB.cpp
+++ b/rdk/ORB/platform-mock/src/DVB.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "DVB.h"
 

--- a/rdk/ORB/platform-mock/src/DVB.h
+++ b/rdk/ORB/platform-mock/src/DVB.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBPlatformMockImpl.h"

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/service/thunder/CMakeLists.txt
+++ b/rdk/ORB/service/thunder/CMakeLists.txt
@@ -1,8 +1,17 @@
 ##
 # ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
 #
-# Licensed under the ORB License that can be found in the LICENSE file at
-# the top level of this repository.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 cmake_minimum_required(VERSION 2.8)
 

--- a/rdk/ORB/service/thunder/interfaces-framework/IORB.h
+++ b/rdk/ORB/service/thunder/interfaces-framework/IORB.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __IORB_H

--- a/rdk/ORB/service/thunder/src/Module.cpp
+++ b/rdk/ORB/service/thunder/src/Module.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "Module.h"

--- a/rdk/ORB/service/thunder/src/Module.h
+++ b/rdk/ORB/service/thunder/src/Module.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/service/thunder/src/ORB.cpp
+++ b/rdk/ORB/service/thunder/src/ORB.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORB.h"

--- a/rdk/ORB/service/thunder/src/ORB.h
+++ b/rdk/ORB/service/thunder/src/ORB.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/service/thunder/src/ORBComRpcClient.cpp
+++ b/rdk/ORB/service/thunder/src/ORBComRpcClient.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBComRpcClient.h"

--- a/rdk/ORB/service/thunder/src/ORBComRpcClient.h
+++ b/rdk/ORB/service/thunder/src/ORBComRpcClient.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/service/thunder/src/ORBComRpcServer.cpp
+++ b/rdk/ORB/service/thunder/src/ORBComRpcServer.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBComRpcServer.h"

--- a/rdk/ORB/service/thunder/src/ORBComRpcServer.h
+++ b/rdk/ORB/service/thunder/src/ORBComRpcServer.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/service/thunder/src/ORBConfiguration.h
+++ b/rdk/ORB/service/thunder/src/ORBConfiguration.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/service/thunder/src/ORBEventListenerImpl.cpp
+++ b/rdk/ORB/service/thunder/src/ORBEventListenerImpl.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBEventListenerImpl.h"

--- a/rdk/ORB/service/thunder/src/ORBEventListenerImpl.h
+++ b/rdk/ORB/service/thunder/src/ORBEventListenerImpl.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/service/thunder/src/ORBImplementation.cpp
+++ b/rdk/ORB/service/thunder/src/ORBImplementation.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBImplementation.h"

--- a/rdk/ORB/service/thunder/src/ORBImplementation.h
+++ b/rdk/ORB/service/thunder/src/ORBImplementation.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORB/service/thunder/src/ORBJsonRpc.cpp
+++ b/rdk/ORB/service/thunder/src/ORBJsonRpc.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "Module.h"

--- a/rdk/ORBBrowser/BrowserConsoleLog.h
+++ b/rdk/ORBBrowser/BrowserConsoleLog.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __BROWSERCONSOLELOG_H

--- a/rdk/ORBBrowser/CMakeLists.txt
+++ b/rdk/ORBBrowser/CMakeLists.txt
@@ -1,8 +1,17 @@
 ##
 # ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
 #
-# Licensed under the ORB License that can be found in the LICENSE file at
-# the top level of this repository.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 cmake_minimum_required(VERSION 3.3)
 

--- a/rdk/ORBBrowser/HTML5Notification.h
+++ b/rdk/ORBBrowser/HTML5Notification.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __HTML5NOTIFICATION_H

--- a/rdk/ORBBrowser/Module.cpp
+++ b/rdk/ORBBrowser/Module.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "Module.h"

--- a/rdk/ORBBrowser/Module.h
+++ b/rdk/ORBBrowser/Module.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __MODULE_PLUGIN_WEBKITBROWSER_H

--- a/rdk/ORBBrowser/ORBBrowser.cpp
+++ b/rdk/ORBBrowser/ORBBrowser.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "ORBBrowser.h"

--- a/rdk/ORBBrowser/ORBBrowser.h
+++ b/rdk/ORBBrowser/ORBBrowser.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __BROWSER_H

--- a/rdk/ORBBrowser/ORBBrowserJsonRpc.cpp
+++ b/rdk/ORBBrowser/ORBBrowserJsonRpc.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "Module.h"

--- a/rdk/ORBBrowser/ORBInjectedBundle/CMakeLists.txt
+++ b/rdk/ORBBrowser/ORBInjectedBundle/CMakeLists.txt
@@ -1,8 +1,17 @@
 ##
 # ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
 #
-# Licensed under the ORB License that can be found in the LICENSE file at
-# the top level of this repository.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 set(PLUGIN_NAME ORBInjectedBundle)
 set(MODULE_NAME WPE${PLUGIN_NAME})

--- a/rdk/ORBBrowser/ORBInjectedBundle/Module.h
+++ b/rdk/ORBBrowser/ORBInjectedBundle/Module.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #ifndef __ORBINJECTEDBUNDLE_MODULE_H
 #define __ORBINJECTEDBUNDLE_MODULE_H

--- a/rdk/ORBBrowser/ORBInjectedBundle/RequestHeaders.cpp
+++ b/rdk/ORBBrowser/ORBInjectedBundle/RequestHeaders.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "RequestHeaders.h"

--- a/rdk/ORBBrowser/ORBInjectedBundle/RequestHeaders.h
+++ b/rdk/ORBBrowser/ORBInjectedBundle/RequestHeaders.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORBBrowser/ORBInjectedBundle/Tags.cpp
+++ b/rdk/ORBBrowser/ORBInjectedBundle/Tags.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "Tags.h"

--- a/rdk/ORBBrowser/ORBInjectedBundle/Tags.h
+++ b/rdk/ORBBrowser/ORBInjectedBundle/Tags.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/rdk/ORBBrowser/ORBInjectedBundle/Utils.cpp
+++ b/rdk/ORBBrowser/ORBInjectedBundle/Utils.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "Utils.h"

--- a/rdk/ORBBrowser/ORBInjectedBundle/Utils.h
+++ b/rdk/ORBBrowser/ORBInjectedBundle/Utils.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __INJECTEDBUNDLE_UTILS_H

--- a/rdk/ORBBrowser/ORBInjectedBundle/WhiteListedOriginDomainsList.cpp
+++ b/rdk/ORBBrowser/ORBInjectedBundle/WhiteListedOriginDomainsList.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "WhiteListedOriginDomainsList.h"

--- a/rdk/ORBBrowser/ORBInjectedBundle/WhiteListedOriginDomainsList.h
+++ b/rdk/ORBBrowser/ORBInjectedBundle/WhiteListedOriginDomainsList.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __WHITELISTEDORIGINDOMAINSLIST_H

--- a/rdk/ORBBrowser/ORBInjectedBundle/main.cpp
+++ b/rdk/ORBBrowser/ORBInjectedBundle/main.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "Module.h"
 

--- a/rdk/ORBBrowser/ORBInjectedBundle/orb/ORBBridge.cpp
+++ b/rdk/ORBBrowser/ORBInjectedBundle/orb/ORBBridge.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "ORBBridge.h"
 #include "Tags.h"

--- a/rdk/ORBBrowser/ORBInjectedBundle/orb/ORBBridge.h
+++ b/rdk/ORBBrowser/ORBInjectedBundle/orb/ORBBridge.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORBBrowser/ORBInjectedBundle/orb/OrbUtils.cpp
+++ b/rdk/ORBBrowser/ORBInjectedBundle/orb/OrbUtils.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /*---includes for this file--------------------------------------------------*/

--- a/rdk/ORBBrowser/ORBInjectedBundle/orb/OrbUtils.h
+++ b/rdk/ORBBrowser/ORBInjectedBundle/orb/OrbUtils.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 // pre-processor mechanism so multiple inclusions don't cause compilation error

--- a/rdk/ORBBrowser/ORBInjectedBundle/orb/WpeBridge.cpp
+++ b/rdk/ORBBrowser/ORBInjectedBundle/orb/WpeBridge.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "WpeBridge.h"
 #include "ORBBridge.h"

--- a/rdk/ORBBrowser/ORBInjectedBundle/orb/WpeBridge.h
+++ b/rdk/ORBBrowser/ORBInjectedBundle/orb/WpeBridge.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBDVBURILoader.cpp
+++ b/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBDVBURILoader.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "ORBDVBURILoader.h"
 #include "ORBWPEWebExtensionHelper.h"

--- a/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBDVBURILoader.h
+++ b/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBDVBURILoader.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBWPEWebExtension.cpp
+++ b/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBWPEWebExtension.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include <cstdio>
 #include <string>

--- a/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBWPEWebExtensionHelper.cpp
+++ b/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBWPEWebExtensionHelper.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #include "ORBWPEWebExtensionHelper.h"
 #include "ORBDVBURILoader.h"

--- a/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBWPEWebExtensionHelper.h
+++ b/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBWPEWebExtensionHelper.h
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 #pragma once
 

--- a/rdk/ORBBrowser/WebKitImplementation.cpp
+++ b/rdk/ORBBrowser/WebKitImplementation.cpp
@@ -1,8 +1,17 @@
 /**
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
  *
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <memory>

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Native-agnostic interface to outside the browser context (e.g. to the broadcast stack).
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/src/core.js
+++ b/src/core.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Service configuration and point of entry for initialisation.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.core = (function() {

--- a/src/drmmanager.js
+++ b/src/drmmanager.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview DRM Manager.
  * @license ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.drmManager = (function() {

--- a/src/holepuncher.js
+++ b/src/holepuncher.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Utiltiies for hole punching.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.holePuncher = (function() {

--- a/src/housekeeping/banner.js
+++ b/src/housekeeping/banner.js
@@ -1,5 +1,14 @@
 /*
  * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */

--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview The proxy for DASH playback.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.DashProxy = (function() {

--- a/src/mediaproxies/eme/mediakeys.js
+++ b/src/mediaproxies/eme/mediakeys.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview MediaKeys class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.MediaKeys = (function() {
     const MEDIA_KEYS_ID = 'MediaKeys';

--- a/src/mediaproxies/eme/mediakeysession.js
+++ b/src/mediaproxies/eme/mediakeysession.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview MediaKeySession class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.MediaKeySession = (function() {
     const MEDIA_KEY_SESSION_ID = 'MediaKeySession';

--- a/src/mediaproxies/eme/mediakeysystemaccess.js
+++ b/src/mediaproxies/eme/mediakeysystemaccess.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview MediaKeySystemAccess class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.MediaKeySystemAccess = (function() {
     const privates = new WeakMap();

--- a/src/mediaproxies/iframeobjectproxy.js
+++ b/src/mediaproxies/iframeobjectproxy.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview IFrameObjectProxy class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.IFrameObjectProxy = (function() {

--- a/src/mediaproxies/mediaelementextension.js
+++ b/src/mediaproxies/mediaelementextension.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview MediaElementExtension class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.MediaElementExtension = (function() {

--- a/src/mediaproxies/mediaerror.js
+++ b/src/mediaproxies/mediaerror.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview MediaError class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.MediaError = (function() {

--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -2,8 +2,17 @@
  * @fileOverview Monitors the document and certain JavaScript mechanisms for objects. Builds or
  * upgrades those objects if there is a registered handler.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.mediaManager = (function() {
     let objectHandlers = {};

--- a/src/mediaproxies/nativeproxy.js
+++ b/src/mediaproxies/nativeproxy.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview The proxy for native playback.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.NativeProxy = (function() {

--- a/src/mediaproxies/run.js
+++ b/src/mediaproxies/run.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Calls initialise at the end of the injected script.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.native.initialise();
 hbbtv.mediaManager.initialise();

--- a/src/mediaproxies/timeranges.js
+++ b/src/mediaproxies/timeranges.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview TimeRanges class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.TimeRanges = (function() {

--- a/src/mediaproxies/tracklists/audiotracklist.js
+++ b/src/mediaproxies/tracklists/audiotracklist.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview AdioTrackList class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.AudioTrackList = (function() {
     const AUDIO_TRACK_KEY_PREFIX = 'AudioTrack_';

--- a/src/mediaproxies/tracklists/texttrack.js
+++ b/src/mediaproxies/tracklists/texttrack.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview TextTrack class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.TextTrack = (function() {
     const prototype = Object.create(TextTrack.prototype);

--- a/src/mediaproxies/tracklists/texttrackcuelist.js
+++ b/src/mediaproxies/tracklists/texttrackcuelist.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview TextTrackCueList class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.TextTrackCueList = (function() {
     const prototype = Object.create(TextTrackCueList.prototype);

--- a/src/mediaproxies/tracklists/texttracklist.js
+++ b/src/mediaproxies/tracklists/texttracklist.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview TextTrackList class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.TextTrackList = (function() {
     const prototype = Object.create(TextTrackList.prototype);

--- a/src/mediaproxies/tracklists/videotracklist.js
+++ b/src/mediaproxies/tracklists/videotracklist.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview VideoTrackList class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.VideoTrackList = (function() {
     const listProto = {};

--- a/src/natives/android.js
+++ b/src/natives/android.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Android native
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.native = {

--- a/src/objectmanager.js
+++ b/src/objectmanager.js
@@ -2,8 +2,17 @@
  * @fileOverview Monitors the document and certain JavaScript mechanisms for objects. Builds or
  * upgrades those objects if there is a registered handler.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects = {};

--- a/src/objects/application.js
+++ b/src/objects/application.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF Application class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#application-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.Application = (function() {

--- a/src/objects/applicationmanager.js
+++ b/src/objects/applicationmanager.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF application manager object.
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#application-oipfApplicationManager}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.ApplicationManager = (function() {

--- a/src/objects/avaudiocomponent.js
+++ b/src/objects/avaudiocomponent.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview OIPF AVAudioComponent class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.AVAudioComponent = (function() {

--- a/src/objects/avcomponent.js
+++ b/src/objects/avcomponent.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview OIPF AVComponent class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.AVComponent = (function() {

--- a/src/objects/avcontrol.js
+++ b/src/objects/avcontrol.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF A/V Control object.
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#av-control-object}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.objects.AVControl = (function() {
     const PLAY_STATE_STOPPED = 0;

--- a/src/objects/avsubtitlecomponent.js
+++ b/src/objects/avsubtitlecomponent.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview OIPF AVSubtitleComponent class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.AVSubtitleComponent = (function() {

--- a/src/objects/avvideocomponent.js
+++ b/src/objects/avvideocomponent.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview OIPF AVVideoComponent class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.AVVideoComponent = (function() {

--- a/src/objects/capabilities/oipfcapabilities.js
+++ b/src/objects/capabilities/oipfcapabilities.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview application/oipfcapabilities embedded object.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/src/objects/channel.js
+++ b/src/objects/channel.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF Channel class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#channel-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.Channel = (function() {

--- a/src/objects/channelconfig.js
+++ b/src/objects/channelconfig.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF ChannelConfig class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#channelconfig-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.ChannelConfig = (function() {

--- a/src/objects/channellist.js
+++ b/src/objects/channellist.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF ChannelList class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#channellist-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.ChannelList = (function() {

--- a/src/objects/collection.js
+++ b/src/objects/collection.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Collection class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.Collection = (function() {

--- a/src/objects/configuration/configuration.js
+++ b/src/objects/configuration/configuration.js
@@ -2,8 +2,17 @@
  * @fileOverview Configuration class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#configuration-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.Configuration = (function() {

--- a/src/objects/configuration/localsystem.js
+++ b/src/objects/configuration/localsystem.js
@@ -2,8 +2,17 @@
  * @fileOverview LocalSystem class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#localsystem-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.LocalSystem = (function() {

--- a/src/objects/configuration/oipfconfiguration.js
+++ b/src/objects/configuration/oipfconfiguration.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF configuration object.
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#application-oipfconfiguration}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.OipfConfiguration = (function() {

--- a/src/objects/csmanager.js
+++ b/src/objects/csmanager.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview application/hbbtvCSManager object
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.CSManager = (function() {

--- a/src/objects/keyset.js
+++ b/src/objects/keyset.js
@@ -2,8 +2,17 @@
  * @fileOverview keyset class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#keyset-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.KeySet = (function() {

--- a/src/objects/mediasync/broadcastobserver.js
+++ b/src/objects/mediasync/broadcastobserver.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview BroadcastObserver class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.BroadcastObserver = (function() {

--- a/src/objects/mediasync/mediaelementobserver.js
+++ b/src/objects/mediasync/mediaelementobserver.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview MediaElementObserver class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.MediaElementObserver = (function() {

--- a/src/objects/mediasync/mediaelementtsclient.js
+++ b/src/objects/mediasync/mediaelementtsclient.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview MediaElementTsClient class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.MediaElementTsClient = (function() {

--- a/src/objects/mediasync/mediasynchroniser.js
+++ b/src/objects/mediasync/mediasynchroniser.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview application/hbbtvMediaSynchroniser object
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.MediaSynchroniser = (function() {

--- a/src/objects/oipfdrmagent.js
+++ b/src/objects/oipfdrmagent.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview OIPF DRM Agent object.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.OipfDrmAgent = (function() {

--- a/src/objects/oipfgatewayinfo.js
+++ b/src/objects/oipfgatewayinfo.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview OIPF Gateway Info object
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.OipfGatewayInfo = (function() {

--- a/src/objects/parentalcontrol/oipfparentalcontrolmanager.js
+++ b/src/objects/parentalcontrol/oipfparentalcontrolmanager.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF application/oipfParentalControlManager object
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#application-oipfparentalcontrolmanager}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.OipfParentalControlManager = (function() {

--- a/src/objects/parentalcontrol/parentalrating.js
+++ b/src/objects/parentalcontrol/parentalrating.js
@@ -2,8 +2,17 @@
  * @fileOverview ParentalRating class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#parentalrating-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.ParentalRating = (function() {

--- a/src/objects/parentalcontrol/parentalratingcollection.js
+++ b/src/objects/parentalcontrol/parentalratingcollection.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview ParentalRatingCollection class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.ParentalRatingCollection = (function() {

--- a/src/objects/parentalcontrol/parentalratingscheme.js
+++ b/src/objects/parentalcontrol/parentalratingscheme.js
@@ -2,8 +2,17 @@
  * @fileOverview ParentalRatingScheme class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#parentalratingscheme-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.ParentalRatingScheme = (function() {

--- a/src/objects/parentalcontrol/parentalratingschemecollection.js
+++ b/src/objects/parentalcontrol/parentalratingschemecollection.js
@@ -2,8 +2,17 @@
  * @fileOverview ParentalRatingSchemeCollection class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#parentalratingschemecollection-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.ParentalRatingSchemeCollection = (function() {

--- a/src/objects/privatedata.js
+++ b/src/objects/privatedata.js
@@ -2,8 +2,17 @@
  * @fileOverview ApplicationPrivateData class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#applicationprivatedata-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.PrivateData = (function() {

--- a/src/objects/programme.js
+++ b/src/objects/programme.js
@@ -2,8 +2,17 @@
  * @fileOverview OIPF Programme class
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#programme-class}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.Programme = (function() {

--- a/src/objects/searchmanager/metadatasearch.js
+++ b/src/objects/searchmanager/metadatasearch.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview MetadataSearch class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /*jshint esversion: 6 */

--- a/src/objects/searchmanager/oipfsearchmanager.js
+++ b/src/objects/searchmanager/oipfsearchmanager.js
@@ -2,8 +2,17 @@
  * @fileOverview The application/oipfSearchManager embedded object.
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#application-oipfsearchmanager}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.OipfSearchManager = (function() {

--- a/src/objects/searchmanager/query.js
+++ b/src/objects/searchmanager/query.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Query class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 let queryIdCounter = 0;
 hbbtv.objects.Query = (function() {

--- a/src/objects/searchmanager/searchresults.js
+++ b/src/objects/searchmanager/searchresults.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview SearchResults class
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.objects.SearchResults = (function() {

--- a/src/objects/videobroadcast.js
+++ b/src/objects/videobroadcast.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview video/broadcast embedded object
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/src/polyfill/close.js
+++ b/src/polyfill/close.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Window close polyfill
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 (function() {

--- a/src/polyfill/debug.js
+++ b/src/polyfill/debug.js
@@ -2,8 +2,17 @@
  * @fileOverview Debug polyfill
  * See: {@link https://web.archive.org/web/20200219165053/http://www.oipf.tv/web-spec/volume5.html#debug-print-api}
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 (function() {

--- a/src/polyfill/keyevent.js
+++ b/src/polyfill/keyevent.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview KeyEvent polyfill
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 (function() {

--- a/src/polyfill/orbdebug.js
+++ b/src/polyfill/orbdebug.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Special ORB methods for debug builds.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.orbDebug = (function() {

--- a/src/polyfill/xhr.js
+++ b/src/polyfill/xhr.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview XHR polyfill
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 (function() {

--- a/src/proprietary/bbc/bbc.js
+++ b/src/proprietary/bbc/bbc.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview BBC API polyfill
  * @license ORB Software. Copyright (c) 2023 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 (function() {

--- a/src/run.js
+++ b/src/run.js
@@ -1,7 +1,16 @@
 /**
  * @fileOverview Calls core initialise at the end of the injected script.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 hbbtv.core.initialise();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,17 @@
 /**
  * @fileOverview Common utiltiies used by objects.
  * @license ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
- * Licensed under the ORB License that can be found in the LICENSE file at
- * the top level of this repository.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 hbbtv.utils = (function() {


### PR DESCRIPTION
This commit updates the licensing for the orb project from the previous ORB License to the Apache License, Version 2.0.