### PR TITLE
add support for enabling/disabling clean audio tracks globally

### DIFF
--- a/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MainActivity.java
+++ b/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MainActivity.java
@@ -60,8 +60,9 @@ public class MainActivity extends Activity {
                 USER_AGENT,
                 SANS_SERIF_FONT_FAMILY,
                 FIXED_FONT_FAMILY,
-                getDoNotTrackEnabled(getApplicationContext())
-        );
+                getDoNotTrackEnabled(getApplicationContext()),
+                getCleanTracksEnabled(getApplicationContext())
+      );
 
         setContentView(R.layout.activity_main);
         Bundle extras = getIntent().getExtras();
@@ -170,6 +171,17 @@ public class MainActivity extends Activity {
             Log.d(TAG, "do_not_track_enabled=unset|0");
             return false;
         }
+    }
+
+    private boolean getCleanTracksEnabled(Context context) {
+      String setting = Settings.Global.getString(context.getContentResolver(), "clean_tracks_enabled");
+      if (setting != null && setting.equals("1")) {
+          Log.d(TAG, "clean_tracks_enabled=1");
+          return true;
+      } else {
+          Log.d(TAG, "clean_tracks_enabled=unset|0");
+          return false;
+      }
     }
 
     public String getHostAddress() {

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
@@ -887,6 +887,18 @@ class Bridge extends AbstractBridge {
     }
 
     /**
+     * Get whether clean audio is enabled on this system.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return True if clean audio is enabled; or false otherwise.
+     */
+    @Override
+    protected boolean Configuration_getCleanAudioEnabled(BridgeToken token) {
+        return mConfiguration.cleanAudioEnabled;
+    }
+
+    /**
      * Get the DVB network IDs of the channels in the broadcast channel list.
      *
      * @param token The token associated with this request.

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSessionFactory.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSessionFactory.java
@@ -70,6 +70,7 @@ public class OrbSessionFactory {
         public final String sansSerifFontFamily;
         public final String fixedFontFamily;
         public final boolean doNotTrackEnabled;
+        public final boolean cleanAudioEnabled;
 
         /**
          *
@@ -83,11 +84,12 @@ public class OrbSessionFactory {
          * @param sansSerifFontFamily
          * @param fixedFontFamily
          * @param doNotTrackEnabled If the user has enabled Do Not Track (DNT).
+         * @param cleanAudioEnabled If the user has enabled clean audio tracks
          */
         public Configuration(int mediaSyncWcPort, int mediaSyncCiiPort, int mediaSyncTsPort,
                              int app2appLocalPort, int app2appRemotePort, String mainActivityUuid, String userAgent,
                              String sansSerifFontFamily, String fixedFontFamily,
-                             boolean doNotTrackEnabled) {
+                             boolean doNotTrackEnabled, boolean cleanAudioEnabled) {
             this.mediaSyncWcPort = mediaSyncWcPort;
             this.mediaSyncCiiPort = mediaSyncCiiPort;
             this.mediaSyncTsPort = mediaSyncTsPort;
@@ -98,6 +100,7 @@ public class OrbSessionFactory {
             this.sansSerifFontFamily = sansSerifFontFamily;
             this.fixedFontFamily = fixedFontFamily;
             this.doNotTrackEnabled = doNotTrackEnabled;
+            this.cleanAudioEnabled = cleanAudioEnabled;
         }
     }
 

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
@@ -1009,6 +1009,15 @@ public abstract class AbstractBridge {
     protected abstract boolean Configuration_getAudioDescriptionEnabled(BridgeToken token);
 
     /**
+     * Get whether clean audio is enabled on this system.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return True if audio description is enabled; or false otherwise.
+     */
+    protected abstract boolean Configuration_getCleanAudioEnabled(BridgeToken token);
+
+    /**
      * Get the DVB network IDs of the channels in the broadcast channel list.
      *
      * @param token The token associated with this request.
@@ -1788,6 +1797,14 @@ public abstract class AbstractBridge {
 
             case "Configuration.getAudioDescriptionEnabled": {
                 boolean result = Configuration_getAudioDescriptionEnabled(
+                        token
+                );
+                response.put("result", result);
+                break;
+            }
+
+            case "Configuration.getCleanAudioEnabled": {
+                boolean result = Configuration_getCleanAudioEnabled(
                         token
                 );
                 response.put("result", result);

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1109,6 +1109,18 @@ hbbtv.bridge.configuration = (function() {
     };
 
     /**
+     * Get whether clean audio is enabled on this system.
+     *
+     * @return {boolean} True if clean audio is enabled; or false otherwise.
+     *
+     * @method
+     * @memberof bridge.configuration#
+     */
+    exported.getCleanAudioEnabled = function() {
+        return hbbtv.native.request('Configuration.getCleanAudioEnabled').result;
+    };
+
+    /**
      * Get the DVB network IDs of the channels in the broadcast channel list.
      *
      * @return {Array.<String>} A list of DVB network IDs; or an empty list of not available.

--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -375,6 +375,7 @@ hbbtv.objects.DashProxy = (function() {
                     numChannels: parseInt(track.audioChannelConfiguration[0]),
                     encoding: track.codec,
                     encrypted: track.contentProtection ? true : false,
+                    accessibility: parseInt(track.accessibility[0]),
                 };
                 tracks.push(info);
             });

--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -27,8 +27,10 @@ hbbtv.mediaManager = (function() {
     hbbtv.bridge = {
         configuration: {
             getPreferredAudioLanguage: () =>
-            hbbtv.native.request('Configuration.getPreferredAudioLanguage').result
-        }
+                hbbtv.native.request('Configuration.getPreferredAudioLanguage').result,
+            getCleanAudioEnabled: () =>
+                hbbtv.native.request('Configuration.getCleanAudioEnabled').result
+        },
     };
 
     function initialise() {

--- a/src/mediaproxies/tracklists/audiotracklist.js
+++ b/src/mediaproxies/tracklists/audiotracklist.js
@@ -107,6 +107,7 @@ hbbtv.objects.AudioTrackList = (function() {
     listProto.orb_setTrackList = function(trackList) {
         let p = privates.get(this);
         let preferredAudioLanguageTrack = null;
+        let cleanAudioTrack = null;
         for (let i = trackList.length; i < this.length; ++i) {
             p.proxy.unregisterObserver(AUDIO_TRACK_KEY_PREFIX + i);
             delete this[i];
@@ -121,6 +122,9 @@ hbbtv.objects.AudioTrackList = (function() {
                         preferredAudioLanguageTrack = this[i];
                 }
             }
+            if (this[i].kind === "alternative" && trackList[i].accessibility === 2) {
+                cleanAudioTrack = this[i];
+            }
         }
 
         privates.get(this).length = trackList.length;
@@ -128,6 +132,12 @@ hbbtv.objects.AudioTrackList = (function() {
         if (preferredAudioLanguageTrack) {
             preferredAudioLanguageTrack.enabled = true;
             p.defaultAudioLanguage = null; // the property is valid only during first playback
+        }
+
+        if (p.cleanAudioEnabled && cleanAudioTrack) {
+            cleanAudioTrack.enabled = true;
+        } else if (!p.cleanAudioEnabled && cleanAudioTrack !== null) {
+            cleanAudioTrack.enabled = false;
         }
     };
 
@@ -185,6 +195,7 @@ hbbtv.objects.AudioTrackList = (function() {
             length: 0,
             eventTarget: document.createDocumentFragment(),
             defaultAudioLanguage: hbbtv.bridge.configuration.getPreferredAudioLanguage(),
+            cleanAudioEnabled: hbbtv.bridge.configuration.getCleanAudioEnabled(),
             proxy,
         });
         proxy.registerObserver(AUDIO_TRACK_LIST_KEY, this);

--- a/src/objects/configuration/configuration.js
+++ b/src/objects/configuration/configuration.js
@@ -17,6 +17,7 @@ hbbtv.objects.Configuration = (function() {
         countryId: hbbtv.bridge.configuration.getCountryId,
         subtitlesEnabled: hbbtv.bridge.configuration.getSubtitlesEnabled,
         audioDescriptionEnabled: hbbtv.bridge.configuration.getAudioDescriptionEnabled,
+        cleanAudioEnabled: hbbtv.bridge.configuration.getCleanAudioEnabled,
         timeShiftSynchronized() {
             return false; // PVR
         },


### PR DESCRIPTION
Description:
Current Android UI does not support audio accessibility options other than enabling audio description. Hbbtv test is failing because the user must disable clean audio before starting the test.  

Proposed Solution:

- Add support for enabling clean audio via Android's global setting configurable from adb shell as below:
  Enable clean audio: **adb shell settings put global clean_tracks_enabled 1**
  Disable clean audio (by default is disabled): **unset or adb shell settings put global clean_tracks_enabled 0**
- Expose configuration option to bridge and retrieve it when generating the audio track lists in order to enable/disable them accordingly
-  Find a way to distinguish different audio accessibility options in dash(proxy) (https://github.com/Dash-Industry-Forum/Ingest/issues/40#issuecomment-463582746)


Tested:
org.hbbtv_MSTRSYNC2130

Notes:
Requires the clean audio configuration options to be also supported in orb-reference repo(s) 