### PR TITLE
video/broadcast object in the stopped state should keep reaising broadcast related events

### DIFF
--- a/src/objects/videobroadcast.js
+++ b/src/objects/videobroadcast.js
@@ -1058,7 +1058,6 @@ hbbtv.objects.VideoBroadcast = (function() {
         if (p.playState === PLAY_STATE_CONNECTING || p.playState === PLAY_STATE_PRESENTING) {
             /* DAE vol5 Table 8 state transition #14 */
             p.playState = PLAY_STATE_STOPPED;
-            removeBridgeEventListeners.call(this);
             hbbtv.holePuncher.setBroadcastVideoObject(null);
             hbbtv.bridge.broadcast.setPresentationSuspended(true);
             dispatchPlayStateChangeEvent.call(this, p.playState);
@@ -1091,7 +1090,7 @@ hbbtv.objects.VideoBroadcast = (function() {
         }
         const component = hbbtv.bridge.broadcast.getPrivateAudioComponent(componentTag);
         if (component !== null) {
-            
+
             // update the currentChannelComponents with the new component
             if (!p.currentChannelComponents) {
                 p.currentChannelComponents = hbbtv.bridge.broadcast.getComponents(
@@ -1100,7 +1099,7 @@ hbbtv.objects.VideoBroadcast = (function() {
                 );
             }
             p.currentChannelComponents.push(component);
-            
+
             return hbbtv.objects.createAVAudioComponent({
                 id: component.id,
                 type: COMPONENT_TYPE_AUDIO,
@@ -1134,7 +1133,7 @@ hbbtv.objects.VideoBroadcast = (function() {
         }
         const component = hbbtv.bridge.broadcast.getPrivateVideoComponent(componentTag);
         if (component !== null) {
-            
+
             // update the currentChannelComponents with the new component
             if (!p.currentChannelComponents) {
                 p.currentChannelComponents = hbbtv.bridge.broadcast.getComponents(
@@ -1677,7 +1676,7 @@ hbbtv.objects.VideoBroadcast = (function() {
         if (!p.onStreamEvent) {
             p.onStreamEvent = (event) => {
                 console.log('Received StreamEvent');
-                console.log(event);
+                console.log(JSON.stringify(event));
                 dispatchStreamEvent.call(
                     this,
                     event.id,


### PR DESCRIPTION
Description:
Current video/broadcast object stops listening events from the bridge when stop() is called. However HbbTV Section 6.2.2.7 states:

> Broadcast related applications that wish to access information from the video/broadcast object, e.g. channelchange
> succeeded events or stream events, while playing broadband content, should put the video/broadcast object into the
> stopped state.

Proposed Solution:
Do not remove bridge event listeners when stop() is called.

Tested:
org.hbbtv_GAPFILLING2870

