### PR TITLE
Fix org.hbbtv_DEMUX0220

### DIFF
--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/WebResourceClient.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/WebResourceClient.java
@@ -232,6 +232,8 @@ abstract class WebResourceClient {
             String fromExtension = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
             if (fromExtension != null) {
                 type = fromExtension;
+            } else if ((extension.equals("html5")) || (extension.equals("cehtml"))) {
+                type = "text/html";
             }
         }
         return type;


### PR DESCRIPTION
Description:
ORB would not display .html5 pages coming from the DSMCC.

Proposed changes:
Use MIME type text/html for files with html5 and cehtml extension

Tested:
org.hbbtv_DEMUX0220

Notes:
Other tests possibly affected by this issue:

- org.hbbtv_MSE0030
- org.hbbtv_DEMUX0020
- org.hbbtv_E1210060
- org.hbbtv_E1210070