### PR TITLE
remove region information from language encoding to match with preferred languages

### DIFF
--- a/src/mediaproxies/tracklists/audiotracklist.js
+++ b/src/mediaproxies/tracklists/audiotracklist.js
@@ -125,9 +125,10 @@ hbbtv.objects.AudioTrackList = (function() {
         for (let i = 0; i < trackList.length; ++i) {
             this[i] = makeAudioTrack(this, i, trackList[i]);
             if (p.defaultAudioLanguage) {
-                if (this[i].language === p.defaultAudioLanguage ||
-                    hbbtv.languageCodes.ISO639_2_to_ISO639_1[this[i].language] === p.defaultAudioLanguage ||
-                    hbbtv.languageCodes.ISO639_2_to_ISO639_1[p.defaultAudioLanguage] === this[i].language) {
+                let trackLanguage = this[i].language.includes('-') ? this[i].language.split('-')[0] : this[i].language;
+                if (trackLanguage === p.defaultAudioLanguage ||
+                    hbbtv.languageCodes.ISO639_2_to_ISO639_1[trackLanguage] === p.defaultAudioLanguage ||
+                    hbbtv.languageCodes.ISO639_2_to_ISO639_1[p.defaultAudioLanguage] === trackLanguage) {
                         preferredAudioLanguageTrack = this[i];
                 }
             }

--- a/src/objects/avcontrol.js
+++ b/src/objects/avcontrol.js
@@ -821,13 +821,14 @@ hbbtv.objects.AVControl = (function() {
                     for (const lang of languages) {
                         for (let i = 0; i < audioTracks.length; ++i) {
                             const track = audioTracks[i];
+                            let trackLanguage = track.language.includes('-') ? track.language.split('-')[0] : track.language;
                             if (
                                 mediaSettings.audio.id === track.id ||
-                                ((track.language === lang ||
-                                        hbbtv.languageCodes.ISO639_2_to_ISO639_1[track.language] ===
+                                ((trackLanguage === lang ||
+                                        hbbtv.languageCodes.ISO639_2_to_ISO639_1[trackLanguage] ===
                                         lang ||
                                         hbbtv.languageCodes.ISO639_2_to_ISO639_1[lang] ===
-                                        track.language) &&
+                                        trackLanguage) &&
                                     (!track.kind ||
                                         track.kind ===
                                         (mediaSettings.audio.roles ?


### PR DESCRIPTION
Description:
audio tracks properties do not match with the preferred language when region information is included in the language encoding string.

Proposed Changes:
remove region information

Tested on:
org.hbbtv_EAC30014_2

 