### PR TITLE
Extended DVB uri handler to handle hbbtv-carousel scheme.

### DIFF
--- a/components/application_manager/application_manager.cpp
+++ b/components/application_manager/application_manager.cpp
@@ -1106,6 +1106,17 @@ uint16_t ApplicationManager::GetKeySet(const uint16_t keyCode)
     return KEY_SET_OTHER;
 }
 
+/**
+ * Provide access to the AIT organization id
+ * 
+ * @return uint32_t the organization id
+ */
+uint32_t ApplicationManager::GetOrganizationId()
+{
+    LOG(LOG_INFO, "The organization id is %d\n", m_app.orgId);
+    return m_app.orgId;
+}
+
 static bool IsKeyNavigation(uint16_t code)
 {
     return code == VK_UP ||

--- a/components/application_manager/application_manager.h
+++ b/components/application_manager/application_manager.h
@@ -228,6 +228,13 @@ public:
         MethodRequirement methodRequirement);
 
     /**
+     * Provide access to the AIT organization id
+     * 
+     * @return uint32_t the organization id
+     */
+    uint32_t GetOrganizationId();
+
+    /**
      * Get the names of the current app.
      *
      * @return The current app names as a map of <lang,name> pairs

--- a/rdk/ORB/library/src/platform/ORBPlatform.h
+++ b/rdk/ORB/library/src/platform/ORBPlatform.h
@@ -561,6 +561,12 @@ public:
     virtual void Dsmcc_UnsubscribeFromStreamEvents(int listenId) = 0;
 
 
+    /**
+     * Request the carousel id of current service.
+     *
+     * @return the carousel id
+     */
+    virtual uint32_t Dsmcc_RequestCarouselId() = 0;
 
     /******************************************************************************
     ** Manager API

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
@@ -1073,6 +1073,16 @@ void ORBPlatformMockImpl::Dsmcc_UnsubscribeFromStreamEvents(int listenId)
     ORB_LOG("listenId=%d", listenId);
 }
 
+/**
+ * Get the current carouselId signaled from PMT
+ *
+ * @return uint32_t the current carouselId
+ */
+uint32_t ORBPlatformMockImpl::Dsmcc_RequestCarouselId()
+{
+    return 1;
+}
+
 /******************************************************************************
 ** Manager API
 *****************************************************************************/

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
@@ -98,6 +98,7 @@ public:
     virtual bool Dsmcc_SubscribeStreamEventId(std::string name, int componentTag, int eventId, int
         listenId) override;
     virtual void Dsmcc_UnsubscribeFromStreamEvents(int listenId) override;
+    virtual uint32_t Dsmcc_RequestCarouselId() override;
 
     // Manager api
     virtual std::string Manager_GetKeyIcon(int keyCode) override;

--- a/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBWPEWebExtensionHelper.cpp
+++ b/rdk/ORBBrowser/ORBWPEWebExtension/src/ORBWPEWebExtensionHelper.cpp
@@ -335,7 +335,11 @@ void ORBWPEWebExtensionHelper::RegisterDVBURLSchemeHandler(WebKitWebContext *con
     ORB_LOG_NO_ARGS();
 
     WebKitSecurityManager *securityManager = webkit_web_context_get_security_manager(context);
+    webkit_security_manager_register_uri_scheme_as_cors_enabled(securityManager, "hbbtv-carousel");
     webkit_security_manager_register_uri_scheme_as_cors_enabled(securityManager, "dvb");
+
+    webkit_web_context_register_uri_scheme(context, "hbbtv-carousel",
+        (WebKitURISchemeRequestCallback) HandleDVBURISchemeRequest, nullptr, nullptr);
 
     webkit_web_context_register_uri_scheme(context, "dvb",
         (WebKitURISchemeRequestCallback) HandleDVBURISchemeRequest, nullptr, nullptr);


### PR DESCRIPTION


Description:
The origin for dvb urls needs to follow the format: hbbtv-carousel://org_id:carousel_id.

Proposed Changes:
Add custom uri handler and provide the original path for the resource. Example:

dvb://1.2.3.4/path/to/resource.ext
hbbtv-carousel://org_id:carousel_id/path/to/resource.ext?dvburl=dvb://1.2.3.4

Tested on:
BBC test: TC-22a

HbbTV Official Testsuite regression testing:
org.hbbtv_DSMCC047 ... org.hbbtv_DSMCC143
