### PR TITLE
HTM-725 Fix bug: time offset and interval for state media

### DIFF
--- a/components/network_services/json_rpc/JsonRpcService.h
+++ b/components/network_services/json_rpc/JsonRpcService.h
@@ -34,7 +34,7 @@ public:
         Title,
         SecondTitle,
         Synopsis,
-        CurrentTime,
+        BiasToSystemTime,
         StartTime,
         EndTime,
         State,
@@ -61,9 +61,9 @@ public:
         std::string title = "";
         std::string secondTitle = "";
         std::string synopsis = "";
-        long long currentTime = -1;
-        long long startTime = -1;
-        long long endTime = -1;
+        int biasToSystemTime = 0;
+        int startTime = -1;
+        int endTime = -1;
         std::string state = "";
         std::unordered_set<std::string> negotiateMethodsAppToTerminal;
         std::unordered_set<std::string> negotiateMethodsTerminalToApp;


### PR DESCRIPTION
Description:
- Change a connection data to BiasToSystemTime
- Use bias for seek-relative intents
- Change the data type of time offset to integer Testing:
- Sending intents of seek-content, seek-relative, seek-live and seek-wallcloc