### PR TITLE
Add component tag as parameter to Dsmcc_RequestCarouselId platform API

### DIFF
--- a/rdk/ORB/library/src/core/SessionCallbackImpl.cpp
+++ b/rdk/ORB/library/src/core/SessionCallbackImpl.cpp
@@ -58,12 +58,6 @@ void SessionCallbackImpl::LoadApplication(uint16_t app_id, const char *url)
     size_t found;
     if ((found = urlStr.rfind("dvb://", 0)) == 0)
     {
-        uint8_t carouselId =
-            ORBEngine::GetSharedInstance().GetORBPlatform()->Dsmcc_RequestCarouselId();
-
-        uint32_t orgId = 
-            ORBEngine::GetSharedInstance().GetApplicationManager()->GetOrganizationId();
-
         std::string baseUrl = urlStr;
         std::string path = "";
         found = urlStr.find('/', found + 6);
@@ -73,6 +67,16 @@ void SessionCallbackImpl::LoadApplication(uint16_t app_id, const char *url)
             baseUrl = urlStr.substr(0, found);
         }
 
+        // get component tag from dvburl
+        uint32_t componentTag=0;
+        sscanf(baseUrl.c_str(), "dvb://%*x.%*x.%*x.%x", &componentTag);
+      
+        uint32_t carouselId =
+            ORBEngine::GetSharedInstance().GetORBPlatform()->Dsmcc_RequestCarouselId(componentTag);
+
+        uint32_t orgId = 
+            ORBEngine::GetSharedInstance().GetApplicationManager()->GetOrganizationId();
+        
         std::string carouselUrl = "hbbtv-carousel://" +
             std::to_string(orgId) + ":" +
             std::to_string(carouselId) +

--- a/rdk/ORB/library/src/platform/ORBPlatform.h
+++ b/rdk/ORB/library/src/platform/ORBPlatform.h
@@ -564,9 +564,11 @@ public:
     /**
      * Request the carousel id of current service.
      *
+     * @param componentTag the component tag provided via dvburl
+     *
      * @return the carousel id
      */
-    virtual uint32_t Dsmcc_RequestCarouselId() = 0;
+    virtual uint32_t Dsmcc_RequestCarouselId(uint32_t componentTag) = 0;
 
     /******************************************************************************
     ** Manager API

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
@@ -1076,9 +1076,11 @@ void ORBPlatformMockImpl::Dsmcc_UnsubscribeFromStreamEvents(int listenId)
 /**
  * Get the current carouselId signaled from PMT
  *
+ * @param componentTag the componentTag provided via dvburl
+ *
  * @return uint32_t the current carouselId
  */
-uint32_t ORBPlatformMockImpl::Dsmcc_RequestCarouselId()
+uint32_t ORBPlatformMockImpl::Dsmcc_RequestCarouselId(uint32_t componentTag)
 {
     return 1;
 }

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
@@ -98,7 +98,7 @@ public:
     virtual bool Dsmcc_SubscribeStreamEventId(std::string name, int componentTag, int eventId, int
         listenId) override;
     virtual void Dsmcc_UnsubscribeFromStreamEvents(int listenId) override;
-    virtual uint32_t Dsmcc_RequestCarouselId() override;
+    virtual uint32_t Dsmcc_RequestCarouselId(uint32_t componentTag) override;
 
     // Manager api
     virtual std::string Manager_GetKeyIcon(int keyCode) override;


### PR DESCRIPTION
Description:
Component tag needs to be included as an argument on Dsmcc_RequestCarouselId platform API of RDK.

Tested on:
BBC test: TC-22a