### PR TITLE
Fix bug after code linter

### DIFF
--- a/src/objectmanager.js
+++ b/src/objectmanager.js
@@ -222,7 +222,7 @@ hbbtv.objectManager = (function() {
             let meta = document.createElement('meta');
             meta.name = 'viewport';
             meta.content = 'width=device-width, initial-scale=1.0';
-            document.getElementsByTagName('head')[0] ? .appendChild(meta);
+            document.getElementsByTagName('head')[0] ?.appendChild(meta);
         }
     }
 


### PR DESCRIPTION
Causes the following error when running org.hbbtv_00001407:

Unable to finalize test step 0 - the application failed to initialize with exception: TypeError: document.getElementById('appmgr').getOwnerApplication is not a function. (In 'document.getElementById('appmgr').getOwnerApplication(document)', 'document.getElementById('appmgr').getOwnerApplication' is undefined)