### PR TITLE
Implementation of additional DVB-I features.

### DIFF
--- a/BuildPolyfill.mk
+++ b/BuildPolyfill.mk
@@ -98,6 +98,5 @@ cat $(addprefix $(1)/,$(polyfill_hbbtv_srcs)) > $(2)/hbbtv.js; \
 if [ $(4) -eq 1 ]; then cat $(addprefix $(1)/,$(polyfill_proprietary_bbc_srcs)) >> $(2)/hbbtv.js; fi; \
 cat $(addprefix $(1)/,src/run.js) >> $(2)/hbbtv.js; \
 cat $(addprefix $(1)/,src/housekeeping/endiffe.js) >> $(2)/hbbtv.js; \
-cp $(addprefix $(1)/,external/playerpage.html) $(2)/playerpage.html; \
-if [ "$(ORB_HBBTV_VERSION)" -ge 204 ]; then cp $(addprefix $(1)/,../dvbi-client/src/main/assets/polyfill/dvbipage.html) $(2)/dvbipage.html; fi)
+cp $(addprefix $(1)/,external/playerpage.html) $(2)/playerpage.html;)
 endef

--- a/BuildPolyfill.mk
+++ b/BuildPolyfill.mk
@@ -45,6 +45,7 @@ src/mediaproxies/tracklists/texttrack.js \
 src/mediaproxies/tracklists/texttrackcuelist.js \
 src/objects/channel.js \
 src/objects/programme.js \
+src/objects/dashevent.js \
 src/objects/channellist.js \
 src/objects/channelconfig.js \
 src/objects/configuration/oipfconfiguration.js \

--- a/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MockOrbSessionCallback.java
+++ b/android/mockorbapp/src/main/java/org/orbtv/mockorbapp/MockOrbSessionCallback.java
@@ -1491,7 +1491,7 @@ public class MockOrbSessionCallback implements IOrbSessionCallback {
                         text = "";
                         status = "error";
                     }
-                    mSession.onDsmccReceiveStreamEvent(listenId, name, data, text, status);
+                    mSession.onDsmccReceiveStreamEvent(listenId, name, data, text, status, null);
                 }
             }
         }, 2000);

--- a/android/orblibrary/src/main/cpp/application_manager_native.cpp
+++ b/android/orblibrary/src/main/cpp/application_manager_native.cpp
@@ -36,7 +36,8 @@
 #define CB_GET_PARENTAL_CONTROL_AGE 8
 #define CB_GET_PARENTAL_CONTROL_REGION 9
 #define CB_GET_PARENTAL_CONTROL_REGION3 10
-#define CB_NUMBER_OF_ITEMS 11
+#define CB_ON_APPLICATION_TYPE_UPDATED 11
+#define CB_NUMBER_OF_ITEMS 12
 
 static jfieldID gJavaManagerPointerField;
 static jmethodID gCb[CB_NUMBER_OF_ITEMS];
@@ -139,6 +140,13 @@ public:
         return region;
     }
 
+    void DispatchApplicationSchemeUpdatedEvent(const std::string &scheme) {
+        JNIEnv *env = JniUtils::GetEnv();
+        jstring j_appType = env->NewStringUTF(scheme.c_str());
+        env->CallVoidMethod(mJavaCbObject, gCb[CB_ON_APPLICATION_TYPE_UPDATED], j_appType);
+        env->DeleteLocalRef(j_appType);
+    }
+
 private:
     jobject mJavaCbObject;
 };
@@ -170,7 +178,9 @@ void InitialiseApplicationManagerNative()
     gCb[CB_GET_PARENTAL_CONTROL_REGION] = env->GetMethodID(managerClass,
         "jniCbonNativeGetParentalControlRegion", "()Ljava/lang/String;");
     gCb[CB_GET_PARENTAL_CONTROL_REGION3] = env->GetMethodID(managerClass,
-        "jniCbonNativeGetParentalControlRegion3", "()Ljava/lang/String;");
+                                                            "jniCbonNativeGetParentalControlRegion3", "()Ljava/lang/String;");
+    gCb[CB_ON_APPLICATION_TYPE_UPDATED] = env->GetMethodID(managerClass,
+                                                            "jniCbonApplicationSchemeUpdated", "(Ljava/lang/String;)V");
 }
 
 extern "C"
@@ -246,6 +256,14 @@ JNIEXPORT jint JNICALL Java_org_orbtv_orblibrary_ApplicationManager_jniGetKeySet
     jint calling_app_id)
 {
     return GetManager(env, object)->GetKeySetMask(calling_app_id);
+}
+
+extern "C"
+JNIEXPORT jstring JNICALL Java_org_orbtv_orblibrary_ApplicationManager_jniGetApplicationScheme(JNIEnv *env,
+                                                                                     jobject object,
+                                                                                     jint calling_app_id)
+{
+    return env->NewStringUTF(GetManager(env, object)->GetApplicationScheme(calling_app_id).c_str());
 }
 
 extern "C"

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/ApplicationManager.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/ApplicationManager.java
@@ -81,6 +81,8 @@ class ApplicationManager {
          */
         void dispatchTransitionedToBroadcastRelatedEvent();
 
+        void dispatchApplicationSchemeUpdatedEvent(String scheme);
+
         /**
          * Notify that the active key set and optional other keys are changed.
          *
@@ -178,6 +180,10 @@ class ApplicationManager {
         return jniSetKeySetMask(appId, value);
     }
 
+    public String getApplicationScheme(int appId) {
+        return jniGetApplicationScheme(appId);
+    }
+
     public void onNetworkAvailabilityChanged(boolean available) {
         jniOnNetworkAvailabilityChanged(available);
     }
@@ -222,6 +228,8 @@ class ApplicationManager {
     private native int jniSetKeySetMask(int appId, int keySetMask);
 
     private native int jniGetKeySetMask(int appId);
+
+    private native String jniGetApplicationScheme(int appId);
 
     private native boolean jniInKeySet(int appId, int keyCode);
 
@@ -368,5 +376,15 @@ class ApplicationManager {
 
     private String jniCbonNativeGetParentalControlRegion3() {
         return (mOrbLibraryCallback != null) ? mOrbLibraryCallback.getCountryId() : "";
+    }
+
+    private void jniCbonApplicationSchemeUpdated(String scheme) {
+        synchronized (mLock) {
+            if (mSessionCallback != null) {
+                mSessionCallback.dispatchApplicationSchemeUpdatedEvent(scheme);
+            } else {
+                Log.e(TAG, "Presentation listener not set.");
+            }
+        }
     }
 }

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
@@ -634,6 +634,10 @@ class Bridge extends AbstractBridge {
         return "";
     }
 
+    protected String Manager_getApplicationScheme(BridgeToken token) {
+        return mApplicationManager.getApplicationScheme(token.getAppId());
+    }
+
     /**
      * Get a list of rating schemes supported by this integration.
      *
@@ -695,14 +699,14 @@ class Bridge extends AbstractBridge {
     protected boolean ParentalControl_isRatingBlocked(BridgeToken token, String scheme, String region,
                                                       int value) {
         // TODO Add 1:1 method to callback
+        int age = mOrbLibraryCallback.getParentalControlAge();
         if (scheme.toLowerCase().equals("dvb-si")) {
             // The value property of the parental rating is equal to
             // the value in DVB-SI rating field + 3 (table A.6 of A.2.28)
             String parentalRegion = mOrbLibraryCallback.getParentalControlRegion().toLowerCase();
-            int age = mOrbLibraryCallback.getParentalControlAge();
             return !parentalRegion.equals(region.toLowerCase()) || age <= value + 3;
         }
-        return false;
+        return age < value;
     }
 
     /**

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSession.java
@@ -283,7 +283,7 @@ public interface IOrbSession {
      * @param name     Name of Stream event
      * @param data     Data asssociated with stream event
      */
-    void onDsmccReceiveStreamEvent(int listenId, String name, String data, String text, String status);
+    void onDsmccReceiveStreamEvent(int listenId, String name, String data, String text, String status, BridgeTypes.DASHEvent dashEvent);
 
     /**
      * Called when the dvbi client has tuned to a specific instance

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
@@ -149,6 +149,11 @@ class OrbSession implements IOrbSession {
                 };
                 handler.post(runnable);
             }
+
+            @Override
+            public void dispatchApplicationSchemeUpdatedEvent(String scheme) {
+                mBridge.dispatchApplicationSchemeUpdatedEvent(scheme);
+            }
         });
 
         mBrowserView.setSessionCallback(new BrowserView.SessionCallback() {
@@ -732,8 +737,8 @@ class OrbSession implements IOrbSession {
      * @param data     Data asssociated with stream event
      */
     @Override
-    public void onDsmccReceiveStreamEvent(int listenId, String name, String data, String text, String status) {
-        mBridge.dispatchStreamEvent(listenId, name, data, text, status);
+    public void onDsmccReceiveStreamEvent(int listenId, String name, String data, String text, String status, BridgeTypes.DASHEvent dashEvent) {
+        mBridge.dispatchStreamEvent(listenId, name, data, text, status, dashEvent);
     }
 
     /**

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
@@ -336,7 +336,7 @@ public abstract class AbstractBridge {
      * @param text The data associated with the stream event, converted to a UTF-8 string.
      * @param status The status of the stream event.
      */
-    public void dispatchStreamEvent(int id, String name, String data, String text, String status) {
+    public void dispatchStreamEvent(int id, String name, String data, String text, String status, BridgeTypes.DASHEvent dashEvent) {
         JSONObject properties = new JSONObject();
         try {
             properties.put("id", id);
@@ -344,6 +344,9 @@ public abstract class AbstractBridge {
             properties.put("data", data);
             properties.put("text", text);
             properties.put("status", status);
+            if (dashEvent != null) {
+                properties.put("DASHEvent", dashEvent.toJSONObject());
+            }
         } catch (JSONException ignored) {
         }
         mSessionCallback.dispatchEvent("StreamEvent", properties);
@@ -443,6 +446,15 @@ public abstract class AbstractBridge {
         } catch (JSONException ignored) {
         }
         mSessionCallback.dispatchEvent("DRMSystemMessage", properties);
+    }
+
+    public void dispatchApplicationSchemeUpdatedEvent(String scheme) {
+        JSONObject properties = new JSONObject();
+        try {
+            properties.put("scheme", scheme);
+        } catch (JSONException ignored) {
+        }
+        mSessionCallback.dispatchEvent("ApplicationSchemeUpdated", properties);
     }
 
     /**
@@ -864,6 +876,15 @@ public abstract class AbstractBridge {
      * @return A URL of an icon that represents the given key; or null if not available.
      */
     protected abstract String Manager_getKeyIcon(BridgeToken token, int code);
+    
+    /**
+     * Get the currently running application scheme.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return The currently running application scheme.
+     */
+    protected abstract String Manager_getApplicationScheme(BridgeToken token);
 
     /**
      * Get a list of rating schemes supported by this integration.
@@ -1692,6 +1713,12 @@ public abstract class AbstractBridge {
                         token,
                         params.getInt("code")
                 );
+                response.put("result", result);
+                break;
+            }
+
+            case "Manager.getApplicationScheme": {
+                String result = Manager_getApplicationScheme(token);
                 response.put("result", result);
                 break;
             }

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeTypes.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeTypes.java
@@ -1167,4 +1167,50 @@ public class BridgeTypes {
         }
         return array;
     }
+
+    public static class DASHEvent implements JSONSerializable {
+        public String Id;
+        public double startTime;
+        public double duration;
+        public String data;
+        public String contentEncoding;
+
+        public DASHEvent(String Id, double startTime, double duration, String data, String contentEncoding) {
+            this.Id = Id;
+            this.startTime = startTime;
+            this.duration = duration;
+            this.data = data;
+            this.contentEncoding = contentEncoding;
+        }
+
+        @Override
+        public JSONObject toJSONObject() throws JSONException {
+            JSONObject o = new JSONObject();
+            if (Id != null) {
+                o.put("Id", Id);
+            }
+            else {
+                o.put("Id", "");
+            }
+            if (data != null) {
+                o.put("data", data);
+            }
+            else {
+                o.put("data", "");
+            }
+            if (contentEncoding != null) {
+                o.put("contentEncoding", contentEncoding);
+            }
+            else {
+                o.put("contentEncoding", "string");
+            }
+            if (startTime >= 0.0) {
+                o.put("startTime", startTime);
+            }
+            if (duration >= 0.0) {
+                o.put("duration", duration);
+            }
+            return o;
+        }
+    }
 }

--- a/components/application_manager/ait.cpp
+++ b/components/application_manager/ait.cpp
@@ -98,7 +98,6 @@ bool Ait::ProcessSection(const uint8_t *data, uint32_t nbytes)
         if (m_ait != nullptr && m_ait->complete)
         {
             m_aitCompleted = std::make_shared<S_AIT_TABLE>(*m_ait);
-            m_aitCompleted->scheme = LINKED_APP_SCHEME_1_1; // by default all broadcast apps are 1.1 version
             updated = true;
         }
     }
@@ -285,6 +284,7 @@ bool Ait::PrintInfo(const S_AIT_TABLE *parsedAit)
         hAitApp = sTable->appArray[i];
         LOG(LOG_INFO, "\tApplication ID: %d", hAitApp.appId);
         LOG(LOG_INFO, "\tOrganization ID: %d", hAitApp.orgId);
+        LOG(LOG_INFO, "\tClassification scheme: %s", hAitApp.scheme.c_str());
         LOG(LOG_INFO, "\tNumber of transports: %d", hAitApp.numTransports);
         for (int j = 0; j < hAitApp.numTransports; j++)
         {
@@ -362,7 +362,6 @@ bool Ait::PrintInfo(const S_AIT_TABLE *parsedAit)
                 hAitApp.parentalRatings[j].region.c_str());
         }
     }
-    LOG(LOG_INFO, "Classification scheme: %s", sTable->scheme.c_str());
     return true;
 }
 

--- a/components/application_manager/ait.h
+++ b/components/application_manager/ait.h
@@ -160,6 +160,7 @@ public:
         uint8_t usageType;
         std::vector<std::string> boundaries;
         std::vector<S_APP_PARENTAL_RATING> parentalRatings;
+        std::string scheme;
     } S_AIT_APP_DESC;
 
     typedef struct
@@ -170,7 +171,6 @@ public:
         uint8_t numApps;
         std::vector<S_AIT_APP_DESC> appArray;
         bool complete;
-        std::string scheme;
     } S_AIT_TABLE;
 
     /**

--- a/components/application_manager/app.cpp
+++ b/components/application_manager/app.cpp
@@ -21,6 +21,9 @@
 #include "app.h"
 #include "log.h"
 
+static std::string getAppSchemeFromUrlParams(const std::string &urlParams);
+static std::string getUrlParamsFromAppScheme(const std::string &scheme);
+
 App App::CreateAppFromUrl(const std::string &url)
 {
     App app;
@@ -42,6 +45,7 @@ App App::CreateAppFromUrl(const std::string &url)
     app.isHidden = false;
 
     app.isRunning = !app.entryUrl.empty();
+    app.setScheme(getAppSchemeFromUrlParams(url));
 
     return app;
 }
@@ -89,5 +93,50 @@ App App::CreateAppFromAitDesc(const Ait::S_AIT_APP_DESC *desc,
         app.names[desc->appName.names[i].langCode] = desc->appName.names[i].name;
     }
 
+    app.setScheme(desc->scheme);
+    if (!desc->scheme.empty())
+    {
+        app.entryUrl = Utils::MergeUrlParams("", app.entryUrl,
+                                             getUrlParamsFromAppScheme(app.getScheme()));
+        app.loadedUrl = app.entryUrl;
+    }
+
     return app;
+}
+
+std::string App::getScheme() const {
+    if (!m_scheme.empty()) {
+        return m_scheme;
+    }
+    return LINKED_APP_SCHEME_1_1;
+}
+
+void App::setScheme(std::string value) {
+    m_scheme = value;
+}
+
+std::string getAppSchemeFromUrlParams(const std::string &urlParams)
+{
+    if (urlParams.find("lloc=service") != std::string::npos)
+    {
+        return LINKED_APP_SCHEME_1_2;
+    }
+    if (urlParams.find("lloc=availability") != std::string::npos)
+    {
+        return LINKED_APP_SCHEME_2;
+    }
+    return LINKED_APP_SCHEME_1_1;
+}
+
+std::string getUrlParamsFromAppScheme(const std::string &scheme)
+{
+    if (scheme == LINKED_APP_SCHEME_1_2)
+    {
+        return "?lloc=service";
+    }
+    if (scheme == LINKED_APP_SCHEME_2)
+    {
+        return "?lloc=availability";
+    }
+    return "";
 }

--- a/components/application_manager/app.h
+++ b/components/application_manager/app.h
@@ -28,7 +28,6 @@
 
 #include "utils.h"
 #include "ait.h"
-#include "app.h"
 
 class App
 {
@@ -45,6 +44,9 @@ public:
         const std::string &urlParams,
         bool isBroadcast,
         bool isTrusted);
+
+    std::string getScheme() const;
+    void setScheme(std::string value);
 
     std::string entryUrl;
     std::string loadedUrl;
@@ -71,6 +73,8 @@ public:
     uint16_t id;
     std::vector<Ait::S_APP_PARENTAL_RATING> parentalRatings;
     uint8_t versionMinor;
+private:
+    std::string m_scheme;
 };
 
 #endif // HBBTV_SERVICE_APP_H

--- a/components/application_manager/application_manager.h
+++ b/components/application_manager/application_manager.h
@@ -101,6 +101,8 @@ public:
         virtual std::string GetParentalControlRegion() = 0;
 
         virtual std::string GetParentalControlRegion3() = 0;
+
+        virtual void DispatchApplicationSchemeUpdatedEvent(const std::string &scheme) = 0;
         /**
          *
          */
@@ -286,6 +288,8 @@ public:
      * @param url The URL of the new page.
      */
     void OnApplicationPageChanged(uint16_t appId, const std::string &url);
+
+    std::string GetApplicationScheme(uint16_t appId);
 
 private:
     /**

--- a/rdk/ORB/library/src/core/SessionCallbackImpl.cpp
+++ b/rdk/ORB/library/src/core/SessionCallbackImpl.cpp
@@ -212,4 +212,7 @@ std::string SessionCallbackImpl::GetParentalControlRegion3()
 {
     return ORBEngine::GetSharedInstance().GetORBPlatform()->ParentalControl_GetRegion3();
 }
+
+void SessionCallbackImpl::DispatchApplicationSchemeUpdatedEvent(const std::string &scheme) { }
+
 } // namespace orb

--- a/rdk/ORB/library/src/core/SessionCallbackImpl.h
+++ b/rdk/ORB/library/src/core/SessionCallbackImpl.h
@@ -122,5 +122,7 @@ public:
      * @return The 3-character country code
      */
     virtual std::string GetParentalControlRegion3() override;
+
+    virtual void DispatchApplicationSchemeUpdatedEvent(uint16_t app_id, const std::string &scheme) override;
 }; // class SessionCallbackImpl
 } // namespace orb

--- a/rdk/ORB/library/src/core/SessionCallbackImpl.h
+++ b/rdk/ORB/library/src/core/SessionCallbackImpl.h
@@ -123,6 +123,6 @@ public:
      */
     virtual std::string GetParentalControlRegion3() override;
 
-    virtual void DispatchApplicationSchemeUpdatedEvent(uint16_t app_id, const std::string &scheme) override;
+    virtual void DispatchApplicationSchemeUpdatedEvent(const std::string &scheme) override;
 }; // class SessionCallbackImpl
 } // namespace orb

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -757,6 +757,10 @@ hbbtv.bridge.manager = (function() {
         }).result;
     };
 
+    exported.getApplicationScheme = function() {
+        return hbbtv.native.request('Manager.getApplicationScheme').result;
+    }
+
     return exported;
 })();
 

--- a/src/objects/applicationmanager.js
+++ b/src/objects/applicationmanager.js
@@ -20,6 +20,8 @@ hbbtv.objects.ApplicationManager = (function() {
     const prototype = Object.create(HTMLObjectElement.prototype);
     const privates = new WeakMap();
     const gGarbageCollectionBlocked = new Set();
+    const LINKED_APP_SCHEME_1_2 = "urn:dvb:metadata:cs:LinkedApplicationCS:2019:1.2";
+    const LINKED_APP_SCHEME_2 = "urn:dvb:metadata:cs:LinkedApplicationCS:2019:2";
 
     prototype.getOwnerApplication = function(page) {
         return hbbtv.objects.createApplication({
@@ -94,6 +96,23 @@ hbbtv.objects.ApplicationManager = (function() {
             privates.get(this).eventDispatcher.dispatchEvent(ev);
         };
         hbbtv.bridge.addWeakEventListener('ApplicationLoadError', p.onApplicationLoadError);
+
+        p.onApplicationSchemeUpdated = (event) => {
+            console.log('onApplicationSchemeUpdated', event.scheme);
+            const currentURL = new URL(window.location.href);
+            switch (event.scheme) {
+                case LINKED_APP_SCHEME_1_2:
+                    currentURL.searchParams.set("lloc", "service");
+                    break;
+                case LINKED_APP_SCHEME_2:
+                    currentURL.searchParams.set("lloc", "availability");
+                    break;
+                default:
+                    return;
+            }
+            window.history.replaceState(null, null, currentURL);
+        };
+        hbbtv.bridge.addWeakEventListener('ApplicationSchemeUpdated', p.onApplicationSchemeUpdated);
     }
 
     function initialise() {

--- a/src/objects/configuration/configuration.js
+++ b/src/objects/configuration/configuration.js
@@ -21,6 +21,7 @@ hbbtv.objects.Configuration = (function() {
 
     hbbtv.utils.defineGetterProperties(prototype, {
         preferredAudioLanguage: hbbtv.bridge.configuration.getPreferredAudioLanguage,
+        preferredAudioLanguage47: hbbtv.bridge.configuration.getPreferredAudioLanguage,
         preferredSubtitleLanguage: hbbtv.bridge.configuration.getPreferredSubtitleLanguage,
         preferredUILanguage: hbbtv.bridge.configuration.getPreferredUILanguage,
         countryId: hbbtv.bridge.configuration.getCountryId,

--- a/src/objects/dashevent.js
+++ b/src/objects/dashevent.js
@@ -1,0 +1,61 @@
+hbbtv.objects.DASHEvent = (function() {
+    const prototype = { };
+    const privates = new WeakMap();
+
+    hbbtv.utils.defineGetterProperties(prototype, {
+        pauseOnExit() {
+            return false;
+        },
+        Id() {
+            return privates.get(this).eventData.Id || "";
+        },
+        startTime() {
+            return privates.get(this).eventData.startTime || 0;
+        },
+        endTime() {
+            return privates.get(this).eventData.duration + this.startTime || Number.MAX_VALUE;
+        },
+        data() {
+            return privates.get(this).eventData.data;
+        }
+    });
+
+    // Initialise an instance of prototype
+    function initialise(eventData) {
+        privates.set(this, { eventData });
+        const data = eventData.data;
+        if (data) {
+            if (eventData.contentEncoding === "arrayBuffer") {
+                const uint8Array = new Uint8Array(data.length / 2);
+                for (let i = 0; i < data.length; i += 2) {
+                    uint8Array[i / 2] = parseInt(data.substr(i, 2), 16);
+                }
+                eventData.data = uint8Array;
+            }
+            else {
+                try {
+                    const parser = new DOMParser();
+                    const xmlDoc = parser.parseFromString(data, "text/xml");
+                    const parseErrors = xmlDoc.getElementsByTagName("parsererror");
+                    if (parseErrors.length === 0) {
+                        eventData.data = xmlDoc;
+                    }
+                  } 
+                  catch (e) { }
+            }
+        }
+        console.log(eventData.data);
+
+    }
+
+    return {
+        prototype: prototype,
+        initialise: initialise
+    };
+})();
+
+hbbtv.objects.createDASHEvent = function(eventData) {
+    const obj = Object.create(hbbtv.objects.DASHEvent.prototype);
+    hbbtv.objects.DASHEvent.initialise.call(obj, eventData);
+    return obj;
+};

--- a/src/objects/programme.js
+++ b/src/objects/programme.js
@@ -51,11 +51,7 @@ hbbtv.objects.Programme = (function() {
         },
         longDescription: {
             get: function() {
-                if (privates.get(this).programmeData.longDescription === undefined) {
-                    return privates.get(this).programmeData.description;
-                } else {
-                    return privates.get(this).programmeData.longDescription;
-                }
+                return privates.get(this).programmeData.longDescription;
             },
             set: function(val) {
                 privates.get(this).programmeData.longDescription = val;


### PR DESCRIPTION
* HTM-716: Support for StreamEvents with DVB-I.
* HTM-704: Force applications of type 1.2 and 2 to go up to CONNECTING state and never PRESENTING.
* HTM-704: Update the url parameters for applications of types 1.2 and 2.
* HTM-704: Add the ? character to the urlParams argument, otherwise the url parameters are not separated from the main body of the url.
* HTM-704: Slight refactoring with the application scheme to fix null object dereference on m_ait.Get() call.
* HTM-704: Fixed issue with faulty url params for the application scheme.
* HTM-716: Add support for DVB-I Stream Events.
* HTM-717: Consider parental rating schemes other than dvb-si when checking for blocked content.
* HTM-647: Return undefined if longDescription is not defined instead of falling back to the description.
* HTM-162: Implemented preferredAudioLanguage47 for the Configuration object.