### PR TITLE
add support for changing preferred audio language by the user

### DIFF
--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSession.java
@@ -184,6 +184,13 @@ public interface IOrbSession {
     void onNetworkStatusEvent(boolean connected);
 
     /**
+     * Called when the user changes the audio language
+     *
+     * @param language      The new preferred audio language
+     */
+    void onPreferredAudioLanguageChanged(String language);
+
+    /**
      * Called when the user has decided whether the application at origin should be allowed access to
      * a distinctive identifier.
      *

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
@@ -610,6 +610,16 @@ class OrbSession implements IOrbSession {
     }
 
     /**
+     * Called when the user changes the audio language
+     *
+     * @param language      The new preferred audio language
+     */
+    @Override
+    public void onPreferredAudioLanguageChanged(String language) {
+        mBridge.dispatchPreferredAudioLanguageChanged(language);
+    }
+
+    /**
      * Called when the user has decided whether the application at origin should be allowed access
      * to a distinctive identifier.
      *

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
@@ -280,6 +280,20 @@ public abstract class AbstractBridge {
     }
 
     /**
+     * Called when the user changes the audio language
+     *
+     * @param language      The new preferred audio language
+     */
+    public void dispatchPreferredAudioLanguageChanged(String language) {
+        JSONObject properties = new JSONObject();
+        try {
+            properties.put("language", language);
+        } catch (JSONException ignored) {
+        }
+        mSessionCallback.dispatchEvent("PreferredAudioLanguageChanged", properties);
+    }
+
+    /**
      * Called when the status of a metadata search changes.
      *
      * @param search The ID from the query string that started the search.

--- a/src/mediaproxies/mediaelementextension.js
+++ b/src/mediaproxies/mediaelementextension.js
@@ -526,6 +526,24 @@ hbbtv.objects.MediaElementExtension = (function() {
 
         this.startDate = new Date(NaN);
         this.audioTracks = hbbtv.objects.createAudioTrackList(iframeProxy);
+        hbbtv.bridge.addWeakEventListener('PreferredAudioLanguageChanged', (e) => {
+            const language = e.language;
+            const audiotracks = thiz.audioTracks;
+            let preferredAudioLanguageTrack = null;
+            let trackLanguage = null;
+            for (let i = 0; i < audiotracks.length; ++i) {
+                trackLanguage = audiotracks[i].language;
+                if (trackLanguage === language ||
+                    hbbtv.languageCodes.ISO639_2_to_ISO639_1[trackLanguage] === language ||
+                    hbbtv.languageCodes.ISO639_2_to_ISO639_1[language] === trackLanguage) {
+                    preferredAudioLanguageTrack = audiotracks[i];
+                    if (preferredAudioLanguageTrack.kind === "main") {
+                        preferredAudioLanguageTrack.enabled = true;
+                        return;
+                    }
+                }
+            }
+        });
         this.videoTracks = hbbtv.objects.createVideoTrackList(iframeProxy);
         this.textTracks = hbbtv.objects.createTextTrackList(parent, iframeProxy);
         this.readyState = mediaOwnProperties.readyState.get.call(parent);


### PR DESCRIPTION
Description:
Some hbbtv tests require changing audio language(s) while the app is running explicitly by user interaction with the device. We only support selecting audio tracks either with HTMLmedia or A/V control using javascript APIs.

Proposed changes:
Provide support for changing audio language directly via orb session. Integration should call _dispatchPreferredAudioLanguageChanged_ so as bridge can propagate the language change to media manager. Will work for all supported formats/codecs.

Test:
org.hbbtv_EAC30013
