### PR TITLE
Fix for xhtml parsing error where InjectionInputStream.read() method …

### DIFF
--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/InjectionInputStream.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/InjectionInputStream.java
@@ -95,7 +95,9 @@ abstract class InjectionInputStream extends FilterInputStream {
             if (n == 0 && nbytes == -1) {
                 return -1;
             }
-            n += nbytes;
+            if (nbytes > 0) {
+                n += nbytes;
+            }
         }
         return n;
     }


### PR DESCRIPTION
…reports one less byte than the actual payload size.