### PR TITLE
org.hbbtv_HTML50500 (RDK)

### DIFF
--- a/src/mediaproxies/nativeproxy.js
+++ b/src/mediaproxies/nativeproxy.js
@@ -157,6 +157,11 @@ hbbtv.objects.NativeProxy = (function() {
                 for (const key in track) {
                     t[key] = track[key];
                 }
+                // ensure correct form (gstreamer)
+                if (!isNaN(t.id)) 
+                {
+                    t.id = parseInt(track.id).toString();
+                }
                 t.index = videoTrackList.length;
                 t.encoding = undefined;
                 t.encrypted = false;
@@ -175,6 +180,11 @@ hbbtv.objects.NativeProxy = (function() {
                 const t = {};
                 for (const key in track) {
                     t[key] = track[key];
+                }
+                // ensure correct form (gstreamer)
+                if (!isNaN(t.id)) 
+                {
+                    t.id = parseInt(track.id).toString();
                 }
                 t.numChannels = 2;
                 t.index = audioTrackList.length;


### PR DESCRIPTION
Description:
WPE-WebKit returns strings of the following form "001", "002", ... as video and audio track ids. Apply a fix in nativeproxy to transform these strings to the following form: "1", "2", ...

Testing:

 org.hbbtv_HTML50500
 org.hbbtv_HTML50710