### PR TITLE
HBBTV-34: Inconsistency between when a DSD is base64 encode/decode

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -157,7 +157,11 @@ hbbtv.bridge.broadcast = (function() {
      * @memberof bridge.broadcast#
      */
     exported.getCurrentChannel = function() {
-        return hbbtv.native.request('Broadcast.getCurrentChannel').result;
+        let currentChannel = hbbtv.native.request('Broadcast.getCurrentChannel').result;
+        if (currentChannel.idType === hbbtv.objects.Channel.prototype.ID_DVB_SI_DIRECT) {
+            currentChannel.dsd = hbbtv.utils.base64Decode(currentChannel.dsd);
+        }
+        return currentChannel; 
     };
 
     /**
@@ -175,7 +179,11 @@ hbbtv.bridge.broadcast = (function() {
      * @memberof bridge.broadcast#
      */
     exported.getCurrentChannelForEvent = function() {
-        return hbbtv.native.request('Broadcast.getCurrentChannelForEvent').result;
+        let getCurrentChannelForEvent = hbbtv.native.request('Broadcast.getCurrentChannelForEvent').result;
+        if (getCurrentChannelForEvent.idType === hbbtv.objects.Channel.prototype.ID_DVB_SI_DIRECT) {
+            getCurrentChannelForEvent.dsd = hbbtv.utils.base64Decode(getCurrentChannelForEvent.dsd);
+        }
+        return getCurrentChannelForEvent; 
     };
 
     /**
@@ -190,7 +198,13 @@ hbbtv.bridge.broadcast = (function() {
      * @memberof bridge.broadcast#
      */
     exported.getChannelList = function() {
-        return hbbtv.native.request('Broadcast.getChannelList').result;
+        let channelList = hbbtv.native.request('Broadcast.getChannelList').result;
+        channelList.forEach(channel => {
+            if (channel.idType === hbbtv.objects.Channel.prototype.ID_DVB_SI_DIRECT) {
+                channel.dsd = hbbtv.utils.base64Decode(channel.dsd);
+            }
+        });
+        return channelList;
     };
 
     /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,6 +117,10 @@ hbbtv.utils = (function() {
         return result;
     }
 
+    function base64Decode(str) {
+        return atob(str);
+    }
+
     function insertAfter(thiz, child, sibling) {
         if (thiz) {
             const nextSibling = sibling.nextSibling;
@@ -292,6 +296,7 @@ hbbtv.utils = (function() {
         defineGetterSetterProperties: defineGetterSetterProperties,
         preventDefaultMediaHandling: preventDefaultMediaHandling,
         base64Encode: base64Encode,
+        base64Decode: base64Decode,
         insertAfter: insertAfter,
         matchElementStyle: matchElementStyle,
         EventDispatcher: EventDispatcher,


### PR DESCRIPTION
Description
There is an inconsistency between storing the dsd internally and passing the dsd to the native implementation. Provide a fix that will treat dsd as always being in base64 form when received from the platform. Decode it when requested and the channel is for idType ID_DVB_SI_DIRECT

Testing:
MITXperts get and set channel, channel list.