### PR TITLE
Override xhr open in case of RDK native to create absolute dvb urls

### DIFF
--- a/src/polyfill/xhr.js
+++ b/src/polyfill/xhr.js
@@ -27,4 +27,29 @@
             '' :
             _getAllResponseHeaders.call(this);
     };
+
+    if (hbbtv.native.name === "rdk") {
+        const _open = window.XMLHttpRequest.prototype.open;
+        window.XMLHttpRequest.prototype.open = function(method, url, async, user, password) {
+            const baseUrl = (window.document.getElementsByTagName('base')[0] ?? document.createElement('base')).href;
+            if(baseUrl.length > 0) {
+                if(url.startsWith("dvb:/") && !url.startsWith("dvb://")) {
+                    let newbase;
+                    const dvbTag="dvb:";
+                    if(baseUrl.startsWith("dvb://")) {
+                        newbase = baseUrl.substring(0, baseUrl.lastIndexOf("/"));
+                        url = newbase + url.substring(dvbTag.length);
+                    } else {
+                        const dvburlTag = "dvburl=";
+                        const urlIdx = baseUrl.lastIndexOf(dvburlTag);
+                        if(urlIdx) {
+                            newbase = baseUrl.substring(urlIdx + dvburlTag.length);
+                            url = newbase + url.substring(dvbTag.length);
+                        }
+                    }
+                }
+            }
+            return _open.call(this,method,url,async,user,password);
+        };
+    }
 })();


### PR DESCRIPTION
Description:
Support 7.2.5.3 base tag for relative dvb urls

Tests:
BBC tc16