### PR TITLE
Set env variable for port whitelisting (WPE-2.38)

### DIFF
--- a/rdk/ORBBrowser/WebKitImplementation.cpp
+++ b/rdk/ORBBrowser/WebKitImplementation.cpp
@@ -2429,6 +2429,9 @@ private:
         setenv("HBBTV_ENABLED", "1", 1);
         setenv("WPE_DISABLE_XHR_RESPONSE_CACHING_FOR_PROTOCOLS", "dvb,hbbtv-carousel", 1);
 
+        // Set the environment variables needed by WPE 2.38
+        setenv("WPE_WHITELIST_ALL_PORTS_FOR_PROTOCOLS", "dvb,hbbtv-carousel", 1);
+        
         WebKitWebContext *context;
         if (automationEnabled)
         {


### PR DESCRIPTION
Description:
WPE-2.38 requires an environment variable for the definition of protocols that need to be whitelisted in port checking. 
Whitelist dvb and hbbtv-carousel schemes

Tests:
 	org.hbbtv_DSMCC014
 	...
 	org.hbbtv_DSMCC019
 	org.hbbtv_DSMCC040
 	org.hbbtv_DSMCC044
 	org.hbbtv_DSMCC046