### PR TITLE
HTM-746 handle rendering resolutions with graphics constraints

### DIFF
--- a/android/mock204app/src/main/java/org/orbtv/mock204app/MockAit.java
+++ b/android/mock204app/src/main/java/org/orbtv/mock204app/MockAit.java
@@ -27,6 +27,7 @@ class MockAit {
         public String name;
         public String baseUrl;
         public String initialPath;
+        public Vector<Integer> graphics;
     }
 
     private final Vector<Byte> bytes = new Vector<>();
@@ -37,8 +38,8 @@ class MockAit {
 
         int appLoopLength = 0;
         for (MockAit.Application application : applications) {
-            appLoopLength += 35 + application.name.length() + application.baseUrl.length() +
-                    application.initialPath.length();
+            appLoopLength += 38 + application.name.length() + application.baseUrl.length() +
+                    application.initialPath.length() + application.graphics.size();
         }
 
         insert(0x74, 8); // table_id
@@ -60,8 +61,8 @@ class MockAit {
 
         // applications
         for (MockAit.Application application : applications) {
-            int descLoopLength = 26 + application.name.length() + application.baseUrl.length() +
-                    application.initialPath.length();
+            int descLoopLength = 29 + application.name.length() + application.baseUrl.length() +
+                    application.initialPath.length() + application.graphics.size();
 
             insert(application.orgId, 32); // application_identifier/organisation_id
             insert(application.id, 16); // application_identifier/application_id
@@ -111,6 +112,17 @@ class MockAit {
             insert(application.initialPath.length(), 8); // descriptor_length
             for (char ch : application.initialPath.toCharArray()) {
                 insert(ch, 8);
+            }
+
+            // graphics_constraints_descriptor
+            insert(0x14, 8); // descriptor_tag
+            insert(1 + application.graphics.size(), 8); // descriptor_length
+            insert(0b11111, 5); // reserved_future_use
+            insert(0, 1); // can_run_without_visible_ui
+            insert(0, 1); // handles_configuration_changed
+            insert(0, 1); // handles_externally_controlled_video
+            for (Integer i : application.graphics) {
+                insert(i, 8);  // graphics_configuration_byte
             }
         }
 

--- a/android/mock204app/src/main/java/org/orbtv/mock204app/TestSuiteScenario.java
+++ b/android/mock204app/src/main/java/org/orbtv/mock204app/TestSuiteScenario.java
@@ -228,6 +228,13 @@ public class TestSuiteScenario {
             application.baseUrl = info.getString("baseUrl").replace("$LOCALHOST",
                     mLocalHost);
             application.initialPath = info.getString("initialPath");
+            application.graphics = new Vector<>();
+            if (info.has("graphics")) {
+                JSONArray graphics = info.getJSONArray("graphics");
+                for (int j = 0; j < graphics.length(); ++j) {
+                    application.graphics.add(graphics.getInt(j));
+                }
+            }
             parsed.add(application);
         }
         return parsed;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/ApplicationManager.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/ApplicationManager.java
@@ -46,8 +46,9 @@ class ApplicationManager {
          *
          * @param appId The application ID.
          * @param entryUrl The entry page URL.
+         * @param graphics The list of the co-ordinate graphics supported by the application
          */
-        void loadApplication(int appId, String entryUrl);
+        void loadApplication(int appId, String entryUrl, int[] graphics);
 
         /**
          * Tell the browser to show the application.
@@ -275,12 +276,12 @@ class ApplicationManager {
         }
     }
 
-    private void jniCbLoadApplication(int appId, String entryUrl) {
+    private void jniCbLoadApplication(int appId, String entryUrl, int[] graphics) {
         synchronized (mLock) {
             m_entryUrl = entryUrl;
             if (mSessionCallback != null) {
                 mSessionCallback.resetBroadcastPresentation();
-                mSessionCallback.loadApplication(appId, entryUrl);
+                mSessionCallback.loadApplication(appId, entryUrl, graphics);
                 if (m_entryUrl.equals(NOT_STARTED_URL)) {
                     mSessionCallback.notifyApplicationStatusChanged(
                             IOrbSessionCallback.ApplicationStatus.NOT_STARTED);
@@ -338,8 +339,7 @@ class ApplicationManager {
             if (!okResponse.isSuccessful()) {
                 return "";
             }
-            String contents = okResponse.body().string();
-            return contents;
+            return okResponse.body().string();
         } catch (Exception e) {
             e.printStackTrace();
             return "";

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
@@ -710,6 +710,18 @@ class Bridge extends AbstractBridge {
     }
 
     /**
+     * Get the current resolution supported by the terminal.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return An integer value of the rendering resolution.
+     */
+    @Override
+    protected int Configuration_getRenderingResolution(BridgeToken token) {
+        return mTvBrowserSession.getRenderingResolution();
+    }
+
+    /**
      * Get the current capabilities of the terminal.
      *
      * @param token The token associated with this request.

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSession.java
@@ -105,6 +105,13 @@ public interface IOrbSession {
     String getApp2AppRemoteBaseUrl();
 
     /**
+     * Get the current resolution supported by the terminal.
+     *
+     * @return An integer value of the rendering resolution.
+     */
+    int getRenderingResolution();
+
+    /**
      * Launches a "Broadcast-INDEPENDENT" application, the url could be an XML-AIT file.
      *
      * @param url URL where application is to be found

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
@@ -60,10 +60,11 @@ class OrbSession implements IOrbSession {
              *
              * @param appId The application ID.
              * @param entryUrl The entry page URL.
+             * @param graphics The list of the co-ordinate graphics supported by the application
              */
             @Override
-            public void loadApplication(int appId, String entryUrl) {
-                mBrowserView.loadApplication(appId, entryUrl);
+            public void loadApplication(int appId, String entryUrl, int[] graphics) {
+                mBrowserView.loadApplication(appId, entryUrl, configuration.deviceResolution, graphics);
             }
 
             /**
@@ -366,6 +367,16 @@ class OrbSession implements IOrbSession {
                 mConfiguration.app2appRemotePort +
                 "/hbbtv/" +
                 mConfiguration.mainActivityUuid + "/";
+    }
+
+    /**
+     * Get the current resolution supported by the terminal.
+     *
+     * @return An integer value of the rendering resolution.
+     */
+    @Override
+    public int getRenderingResolution() {
+        return mBrowserView.getRenderingResolution();
     }
 
     /**

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSessionFactory.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSessionFactory.java
@@ -81,6 +81,7 @@ public class OrbSessionFactory {
         public final String fixedFontFamily;
         public final boolean doNotTrackEnabled;
         public final boolean cleanAudioEnabled;
+        public final int deviceResolution = 1080;
 
         /**
          *

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
@@ -919,6 +919,15 @@ public abstract class AbstractBridge {
     protected abstract boolean ParentalControl_isRatingBlocked(BridgeToken token, String scheme, String region, int value);
 
     /**
+     * Get the current resolution supported by the terminal.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return An integer value of the rendering resolution.
+     */
+    protected abstract int Configuration_getRenderingResolution(BridgeToken token);
+
+    /**
      * Get the current capabilities of the terminal.
      *
      * @param token The token associated with this request.
@@ -1746,6 +1755,14 @@ public abstract class AbstractBridge {
                         params.getString("scheme"),
                         params.getString("region"),
                         params.getInt("value")
+                );
+                response.put("result", result);
+                break;
+            }
+
+            case "Configuration.getRenderingResolution": {
+                int result = Configuration_getRenderingResolution(
+                        token
                 );
                 response.put("result", result);
                 break;

--- a/components/application_manager/ait.h
+++ b/components/application_manager/ait.h
@@ -160,6 +160,7 @@ public:
         uint8_t usageType;
         std::vector<std::string> boundaries;
         std::vector<S_APP_PARENTAL_RATING> parentalRatings;
+        std::vector<uint16_t> graphicsConstraints;
         std::string scheme;
     } S_AIT_APP_DESC;
 
@@ -308,6 +309,8 @@ private:
     static void ParseSimpleAppBoundaryDesc(const uint8_t *dataPtr, S_AIT_APP_DESC *appPtr);
 
     static void ParseParentalRatingDesc(const uint8_t *dataPtr, S_AIT_APP_DESC *appPtr);
+
+    static void ParseGraphicsConstraints(const uint8_t *dataPtr, S_AIT_APP_DESC *appPtr);
 
     /**
      *

--- a/components/application_manager/app.cpp
+++ b/components/application_manager/app.cpp
@@ -68,6 +68,7 @@ App App::CreateAppFromAitDesc(const Ait::S_AIT_APP_DESC *desc,
     app.controlCode = desc->controlCode;
     app.orgId = desc->orgId;
     app.appId = desc->appId;
+    app.graphicsConstraints = desc->graphicsConstraints;
 
     app.keySetMask = 0;
 

--- a/components/application_manager/app.h
+++ b/components/application_manager/app.h
@@ -72,6 +72,7 @@ public:
     bool isActivated = true;
     uint16_t id;
     std::vector<Ait::S_APP_PARENTAL_RATING> parentalRatings;
+    std::vector<uint16_t> graphicsConstraints;
     uint8_t versionMinor;
 private:
     std::string m_scheme;

--- a/components/application_manager/application_manager.cpp
+++ b/components/application_manager/application_manager.cpp
@@ -264,7 +264,7 @@ uint16_t ApplicationManager::SetKeySetMask(uint16_t appId, uint16_t keySetMask)
     if (m_app.id == appId)
     {
         if (!m_app.isActivated && m_app.getScheme() != LINKED_APP_SCHEME_1_2 &&
-            m_app.getScheme()  != LINKED_APP_SCHEME_2)
+            m_app.getScheme() != LINKED_APP_SCHEME_2)
         {
             if ((keySetMask & KEY_SET_VCR) != 0)
             {
@@ -421,7 +421,8 @@ bool ApplicationManager::ProcessXmlAit(const std::string &xmlAit, const bool &is
         return false;
     }
 
-    std::unique_ptr<Ait::S_AIT_TABLE> aitTable = XmlParser::ParseAit(xmlAit.c_str(), xmlAit.length());
+    std::unique_ptr<Ait::S_AIT_TABLE> aitTable = XmlParser::ParseAit(xmlAit.c_str(),
+        xmlAit.length());
     if (nullptr == aitTable || aitTable->numApps == 0)
     {
         // No AIT or apps parsed, early out
@@ -953,7 +954,8 @@ bool ApplicationManager::RunApp(const App &app)
             }
         }
 
-        m_sessionCallback->LoadApplication(m_app.id, m_app.entryUrl.c_str());
+        m_sessionCallback->LoadApplication(m_app.id, m_app.entryUrl.c_str(),
+            m_app.graphicsConstraints.size(), m_app.graphicsConstraints);
 
         if (!m_app.isHidden)
         {

--- a/components/application_manager/application_manager.h
+++ b/components/application_manager/application_manager.h
@@ -57,6 +57,18 @@ public:
         virtual void LoadApplication(uint16_t appId, const char *entryUrl) = 0;
 
         /**
+         * Tell the browser to load an application. If the entry page fails to load, the browser
+         * should call ApplicationManager::OnLoadApplicationFailed.
+         *
+         * @param appId The application ID.
+         * @param entryUrl The entry page URL.
+         * @param size The number of the co-ordinate graphics
+         * @param graphics The list of the co-ordinate graphics supported by the application
+         */
+        virtual void LoadApplication(uint16_t appId, const char *entryUrl, int size, const
+            std::vector<uint16_t> graphics) = 0;
+
+        /**
          * Tell the browser to show the loaded application.
          */
         virtual void ShowApplication() = 0;

--- a/components/application_manager/xml_parser.cpp
+++ b/components/application_manager/xml_parser.cpp
@@ -472,6 +472,51 @@ static void XmlParseAppDescProfile(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr
  * @param node
  * @param app_ptr
  */
+static void XmlParseAppDescGraphics(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr)
+{
+    const xmlChar *cptr;
+    xmlChar *dptr;
+
+    node = node->xmlChildrenNode;
+    app_ptr->graphicsConstraints.push_back(720);
+    while (node != nullptr)
+    {
+        if (node->type == XML_ELEMENT_NODE)
+        {
+            cptr = node->name;
+            if (xmlStrEqual(cptr, (const xmlChar *)"GraphicsConfiguration"))
+            {
+                NODE_CONTENT_GET(node, dptr);
+                if (dptr)
+                {
+                    if (xmlStrEqual(dptr, (const
+                                           xmlChar *)"urn:hbbtv:graphics:resolution:1920x1080"))
+                    {
+                        app_ptr->graphicsConstraints.push_back(1080);
+                    }
+                    else if (xmlStrEqual(dptr, (const
+                                                xmlChar *)"urn:hbbtv:graphics:resolution:3840x2160"))
+                    {
+                        app_ptr->graphicsConstraints.push_back(2160);
+                    }
+                    else if (xmlStrEqual(dptr, (const
+                                                xmlChar *)"urn:hbbtv:graphics:resolution:7680x4320"))
+                    {
+                        app_ptr->graphicsConstraints.push_back(4320);
+                    }
+                    NODE_CONTENT_RELEASE();
+                }
+            }
+        }
+        node = node->next;
+    }
+}
+
+/**
+ *
+ * @param node
+ * @param app_ptr
+ */
 static void XmlParseAppDesc(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr)
 {
     const xmlChar *cptr;
@@ -537,6 +582,10 @@ static void XmlParseAppDesc(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr)
                 }
                 pr.value = (uint8_t)XmlGetContentInt(node);
                 app_ptr->parentalRatings.push_back(pr);
+            }
+            else if (xmlStrEqual(cptr, (const xmlChar *)"GraphicsConstraints"))
+            {
+                XmlParseAppDescGraphics(node, app_ptr);
             }
         }
         node = node->next;

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -962,6 +962,18 @@ hbbtv.bridge.configuration = (function() {
     };
 
     /**
+     * Get the current resolution supported by the terminal.
+     *
+     * @return {number} The value of rendering resolution.
+     *
+     * @method
+     * @memberof bridge.configuration#
+     */
+    exported.getRenderingResolution = function() {
+        return hbbtv.native.request('Configuration.getRenderingResolution', {}).result;
+    };
+
+    /**
      * Get a list of audio profiles supported by the terminal, as defined by HBBTV 10.2.4.7 for
      * the audio_profile element.
      *


### PR DESCRIPTION
Questions:
1. Shall we create a dev branch or use other branch, instead of master?
2. Currently there is no test that can support different resolution. Do I need to make efforts to make one?
3. The device resolution is set to a certain value (currently, 1080p, which is set in OrbSession.Configuration.deviceResolution), and if higher resolution is not supported by the app, the rendering resolution will be set to default value (720p) in BrowserView.
4.  So far, I haven't found a proper way to get the original co-ordinate pixels from app. I reckon it should be taken as a default value (720p) in objectmanager.js 
5. On master branch, I found an issue for setInitialScale, which in some circumstances results in extra zoom-in. (like the below screenshot) I could make another pull-request in master?
![image](https://github.com/OpenRedButtonProject/orb/assets/124590262/1846c6e6-d61a-4332-b203-100c3af6c6d6)


HTM-746 handling rendering resolutions with graphics constraints
- update application manager for graphics constraints
- update BrowserView to support different resolutions
- update objectmanager.js for scaling images in web view
Testing:
- manual test with mitxperts

HTM-746 add graphicsConstraints in ait and xml ait
- parse graphicsConstraints in ait and xml ait
- update app