### PR TITLE
Use arguments object for xhr open overload

### DIFF
--- a/src/polyfill/xhr.js
+++ b/src/polyfill/xhr.js
@@ -47,9 +47,10 @@
                             url = newbase + url.substring(dvbTag.length);
                         }
                     }
+                    arguments[1] = url;
                 }
             }
-            return _open.call(this,method,url,async,user,password);
+            return _open.apply(this, arguments);
         };
     }
 })();


### PR DESCRIPTION
Description:
Fix for overloading xhr open in case of rdk client

Tests:
org.hbbtv_AVC01040
org.hbbtv_AVC01050
org.hbbtv_AVC01060