### PR TITLE
Add mapping for ISO1 to ISO2 language codes. Also set language of aud…

### DIFF
--- a/src/languagecodes.js
+++ b/src/languagecodes.js
@@ -205,4 +205,9 @@ hbbtv.languageCodes = {
         zho: 'zh',
         zul: 'zu',
     },
+    makeReverseMapping : function() {
+        return Object.fromEntries(
+            Object.entries(this.ISO639_2_to_ISO639_1).map(([key, value]) => [value, key])
+          );
+    }
 };

--- a/src/objects/avcontrol.js
+++ b/src/objects/avcontrol.js
@@ -641,6 +641,16 @@ hbbtv.objects.AVControl = (function() {
                         } else if (isEAC3(trackEncoding)) {
                             trackEncoding = "E-AC3";
                         }
+                                      
+                        let language = 'und';
+                        if (audioTrack.language) {
+                            if (priv.ISO639_1_to_ISO639_2[audioTrack.language]) {
+                                language = priv.ISO639_1_to_ISO639_2[audioTrack.language];
+                            }
+                            else {
+                                language = audioTrack.language;
+                            }
+                        }
 
                         components.push({
                             // AVComponent properties
@@ -650,7 +660,7 @@ hbbtv.objects.AVControl = (function() {
                             encoding: trackEncoding,
                             encrypted: audioTrack.encrypted,
                             // AVAudioComponent properties
-                            language: audioTrack.language ? audioTrack.language : 'und',
+                            language: language,
                             audioDescription: audioTrack.kind === 'alternate' ||
                                 audioTrack.kind === 'alternative',
                             audioChannels: audioTrack.numChannels,
@@ -1068,6 +1078,7 @@ hbbtv.objects.AVControl = (function() {
         priv.xhr = new XMLHttpRequest();
         const thiz = this;
 
+        priv.ISO639_1_to_ISO639_2 = hbbtv.languageCodes.makeReverseMapping();
         priv.data = Element.prototype.getAttribute.call(this, 'data');
 
         function onPlayHandler() {


### PR DESCRIPTION
Description
WPE-Webkit returns ISO639_1 language codes when populating audiotracks. Provide a way to map these to the expected ISO639_2 codes the spec expects.

Tests:
org.hbbtv_AUDIO_COMMUTING0010
org.hbbtv_AVC01070
org.hbbtv_AVC01140