### PR TITLE
Fix regressions when targetURL is a .xse file

### DIFF
--- a/src/objects/videobroadcast.js
+++ b/src/objects/videobroadcast.js
@@ -1352,7 +1352,7 @@ hbbtv.objects.VideoBroadcast = (function() {
         /* Extensions to video/broadcast for synchronization: No security restrictions specified */
         const p = privates.get(this);
         if (p.playState == PLAY_STATE_PRESENTING || p.playState == PLAY_STATE_STOPPED) {
-            if (targetURL.startsWith('dsmcc:')) {
+            if (targetURL.startsWith('dsmcc:') || targetURL.endsWith('.xse')) {
                 let found = false;
                 let componentTag, streamEventId;
                 let request = new XMLHttpRequest();


### PR DESCRIPTION
Description
Also check if target url is an xse file in videobroadcast.js to pass org.hbbtv_DSMCC005, org.hbbtv_DSMCC007 and org.hbbtv_DSMCC008

Tests
org.hbbtv_DSMCC001
...
org.hbbtv_DSMCC143