### PR TITLE
COD-60 add preferredAudioLanguage47 and preferredSubtitleLanguage47

### DIFF
--- a/src/objects/configuration/configuration.js
+++ b/src/objects/configuration/configuration.js
@@ -23,6 +23,7 @@ hbbtv.objects.Configuration = (function() {
         preferredAudioLanguage: hbbtv.bridge.configuration.getPreferredAudioLanguage,
         preferredAudioLanguage47: hbbtv.bridge.configuration.getPreferredAudioLanguage,
         preferredSubtitleLanguage: hbbtv.bridge.configuration.getPreferredSubtitleLanguage,
+        preferredSubtitleLanguage47: hbbtv.bridge.configuration.getPreferredSubtitleLanguage,
         preferredUILanguage: hbbtv.bridge.configuration.getPreferredUILanguage,
         countryId: hbbtv.bridge.configuration.getCountryId,
         subtitlesEnabled: hbbtv.bridge.configuration.getSubtitlesEnabled,


### PR DESCRIPTION
COD-60 add preferredAudioLanguage47 and preferredSubtitleLanguage47 to configuration for 2.0.4 spec

- add preferredSubtitleLanguage47 with bridge method, getPreferredSubtitleLanguage

Testing:
- manual check with mit-xperts