### PR TITLE
Add timeout to the XHR that requests HEAD info in order to upgrade the media element to the proper proxy.

### DIFF
--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -140,15 +140,16 @@ hbbtv.mediaManager = (function() {
         }
 
         // if no supported extension is found, request the content-type of the source
-        const request = new XMLHttpRequest();
-        request.open('HEAD', src);
-        request.send();
         return new Promise((resolve, reject) => {
+            const request = new XMLHttpRequest();
             request.onabort = request.onerror = () => {
                 reject('An error occurred while requesting the content type.');
             };
+            let timeoutId = -1;
             request.onload = () => {
+                clearTimeout(timeoutId);
                 try {
+                    console.log("marios", request.getAllResponseHeaders());
                     const contentType = request
                         .getAllResponseHeaders()
                         .split('\n')
@@ -171,6 +172,9 @@ hbbtv.mediaManager = (function() {
                     reject(e);
                 }
             };
+            timeoutId = setTimeout(request.onload, 5000);
+            request.open('HEAD', src);
+            request.send();
         });
     }
 


### PR DESCRIPTION
Add timeout to the XHR that requests HEAD info in order to upgrade the media element to the proper proxy.