### PR TITLE
Fix wrong format when converting eventId from string to integer and writing the hex value to buffer

### DIFF
--- a/components/network_services/media_synchroniser/media_synchroniser.cpp
+++ b/components/network_services/media_synchroniser/media_synchroniser.cpp
@@ -976,7 +976,7 @@ void MediaSynchroniserManager::updateDvbInfo(const int &onetId, const int &trans
     {
         std::string extractedId = programmeId.substr(semicolonPos + 1);
         char programmeIdBuffer[5];
-        sprintf(programmeIdBuffer, "%04d", std::stoi(extractedId));
+        sprintf(programmeIdBuffer, "%04x", std::stoi(extractedId, nullptr, 16));
         formattedProgrammeId = programmeIdBuffer;
     }
     else


### PR DESCRIPTION
Convert the extracted eventId in hex string format to integer and write the hex value to char buffer