### PR TITLE
HTM-782, HTM-785 and HTM-786

### DIFF
--- a/android/mock204app/src/main/java/org/orbtv/mock204app/MockOrbSessionCallback.java
+++ b/android/mock204app/src/main/java/org/orbtv/mock204app/MockOrbSessionCallback.java
@@ -1607,7 +1607,10 @@ public class MockOrbSessionCallback implements IOrbSessionCallback {
             // the requested gain value shall be applied.
             appliedGain = dialogueEnhancementGain;
         }
-        MOCK_DIALOGUE_ENHANCEMENT_GAIN = appliedGain;
+        if (MOCK_DIALOGUE_ENHANCEMENT_GAIN != appliedGain) {
+            MOCK_DIALOGUE_ENHANCEMENT_GAIN = appliedGain;
+            onRequestFeatureSettingsQuery(connection, id, F_DIALOGUE_ENHANCEMENT);
+        }
         mSession.onRespondDialogueEnhancementOverride(connection, id, appliedGain);
         consoleLog("Apply dialogue enhancement override, gain: " + appliedGain);
     }

--- a/android/mock204app/src/main/java/org/orbtv/mock204app/MockOrbSessionCallback.java
+++ b/android/mock204app/src/main/java/org/orbtv/mock204app/MockOrbSessionCallback.java
@@ -2022,6 +2022,9 @@ public class MockOrbSessionCallback implements IOrbSessionCallback {
                 consoleLog("Notify settings of in-vision signing, isEnabled: " + isEnabled);
                 break;
             }
+            case KeyEvent.KEYCODE_ESCAPE: {
+                mSession.onExitKeyPress();
+            }
             default:
                 return false;
         }

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSession.java
@@ -113,6 +113,11 @@ public interface IOrbSession {
     boolean launchApplication(String url);
 
     /**
+     * When the user presses the exit key, destroy the calling application.
+     */
+    void onExitKeyPress();
+
+    /**
      * Requests the HbbTV engine to process the specified AIT. The HbbTV engine expects the relevant
      * AITs only (the first one after HBBTV_Start and when the version/PID changes). If more than one
      * stream is signalled in the PMT for a service with an application_signalling_descriptor, then

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
@@ -390,6 +390,14 @@ class OrbSession implements IOrbSession {
     }
 
     /**
+     * When the user presses the exit key, destroy the calling application.
+     */
+    @Override
+    public void onExitKeyPress() {
+        mApplicationManager.destroyApplication(0);
+    }
+
+    /**
      * Requests the HbbTV engine to process the specified AIT. The HbbTV engine expects the
      * relevant AITs only (the first one after HBBTV_Start and when the version/PID changes).
      * If more than one stream is signalled in the PMT for a service with an

--- a/components/application_manager/application_manager.cpp
+++ b/components/application_manager/application_manager.cpp
@@ -204,10 +204,13 @@ void ApplicationManager::DestroyApplication(uint16_t callingAppId)
     std::lock_guard<std::recursive_mutex> lock(m_lock);
 
     LOG(LOG_ERROR, "DestroyApplication");
-
+    if (callingAppId == INVALID_APP_ID) {
+        KillRunningApp();
+        OnRunningAppExited();
+    }
     if (!m_app.isRunning || m_app.id != callingAppId)
     {
-        LOG(LOG_INFO, "Called by non-running app, early out");
+        LOG(LOG_INFO,  "Called by non-running app, early out");
         return;
     }
 

--- a/components/application_manager/application_manager.cpp
+++ b/components/application_manager/application_manager.cpp
@@ -204,13 +204,14 @@ void ApplicationManager::DestroyApplication(uint16_t callingAppId)
     std::lock_guard<std::recursive_mutex> lock(m_lock);
 
     LOG(LOG_ERROR, "DestroyApplication");
-    if (callingAppId == INVALID_APP_ID) {
+    if (callingAppId == INVALID_APP_ID)
+    {
         KillRunningApp();
         OnRunningAppExited();
     }
     if (!m_app.isRunning || m_app.id != callingAppId)
     {
-        LOG(LOG_INFO,  "Called by non-running app, early out");
+        LOG(LOG_INFO, "Called by non-running app, early out");
         return;
     }
 
@@ -267,7 +268,7 @@ uint16_t ApplicationManager::SetKeySetMask(uint16_t appId, uint16_t keySetMask)
     if (m_app.id == appId)
     {
         if (!m_app.isActivated && m_app.getScheme() != LINKED_APP_SCHEME_1_2 &&
-            m_app.getScheme()  != LINKED_APP_SCHEME_2)
+            m_app.getScheme() != LINKED_APP_SCHEME_2)
         {
             if ((keySetMask & KEY_SET_VCR) != 0)
             {
@@ -424,7 +425,8 @@ bool ApplicationManager::ProcessXmlAit(const std::string &xmlAit, const bool &is
         return false;
     }
 
-    std::unique_ptr<Ait::S_AIT_TABLE> aitTable = XmlParser::ParseAit(xmlAit.c_str(), xmlAit.length());
+    std::unique_ptr<Ait::S_AIT_TABLE> aitTable = XmlParser::ParseAit(xmlAit.c_str(),
+        xmlAit.length());
     if (nullptr == aitTable || aitTable->numApps == 0)
     {
         // No AIT or apps parsed, early out

--- a/components/network_services/json_rpc/JsonRpcService.cpp
+++ b/components/network_services/json_rpc/JsonRpcService.cpp
@@ -565,6 +565,11 @@ JsonRpcService::JsonRpcStatus JsonRpcService::RequestDialogueEnhancementOverride
         {
             dialogueEnhancementGain = params["dialogueEnhancementGain"].asInt();
         }
+        else
+        {
+            RespondError(connectionId, id, -24, "Dialogue Enhancement override failed");
+            return JsonRpcStatus::NOTIFICATION_ERROR;
+        }
     }
     m_sessionCallback->RequestDialogueEnhancementOverride(connectionId, id,
         dialogueEnhancementGain);


### PR DESCRIPTION
Description:
- Send a notification with the value of dialogueEnhancementGain field equal to value in dialogueEnhancementOverride request
- KEYCODE_ESCAPE is for supporting VK_EXIT
- When the dialogueEnhancementGain parameter value of "NOTAVALUE" a string, generate a valid JSON-RPC error response message with a code value of -24 and a message value of "Dialogue Enhancement override failed"

https://oceanbluesoftware.atlassian.net/jira/software/projects/HTM/boards/17/backlog?selectedIssue=HTM-785
https://oceanbluesoftware.atlassian.net/jira/software/projects/HTM/boards/17/backlog?selectedIssue=HTM-786
https://oceanbluesoftware.atlassian.net/jira/software/projects/HTM/boards/17/backlog?selectedIssue=HTM-782