### PR TITLE
COD-60 add preferredAudioLanguage47 and preferredSubtitleLanguage47

### DIFF
--- a/android/mock204app/src/main/java/org/orbtv/mock204app/MockOrbSessionCallback.java
+++ b/android/mock204app/src/main/java/org/orbtv/mock204app/MockOrbSessionCallback.java
@@ -575,6 +575,18 @@ public class MockOrbSessionCallback implements IOrbSessionCallback {
     }
 
     /**
+     * @since 204
+     *
+     * Gets a string containing languages to be used for audio playback, in order of preference.
+     *
+     * @return Comma separated string of languages (IETF BCP47 codes)
+     */
+    @Override
+    public String getPreferredAudioLanguage47() {
+        return "en-GB,es-ES,de-DE";
+    }
+
+    /**
      * Gets a string containing languages to be used for subtitles, in order of preference.
      *
      * @return Comma separated string of languages (ISO 639-2 codes)
@@ -582,6 +594,18 @@ public class MockOrbSessionCallback implements IOrbSessionCallback {
     @Override
     public String getPreferredSubtitleLanguage() {
         return "en,eng,spa,gre";
+    }
+
+    /**
+     * @since 204
+     *
+     * Gets a string containing languages to be used for subtitles, in order of preference.
+     *
+     * @return Comma separated string of languages (IETF BCP47 codes)
+     */
+    @Override
+    public String getPreferredSubtitleLanguage47() {
+        return "en-GB,es-ES,de-DE";
     }
 
     /**

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
@@ -843,6 +843,18 @@ class Bridge extends AbstractBridge {
     }
 
     /**
+     * Get preferred languages to be used for audio playback on this system.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return Comma separated string of languages (IETF BCP47 codes), in order of preference.
+     */
+    @Override
+    protected String Configuration_getPreferredAudioLanguage47(BridgeToken token) {
+        return mOrbLibraryCallback.getPreferredAudioLanguage47();
+    }
+
+    /**
      * Get preferred languages to be used for subtitles on this system.
      *
      * @param token The token associated with this request.
@@ -852,6 +864,18 @@ class Bridge extends AbstractBridge {
     @Override
     protected String Configuration_getPreferredSubtitleLanguage(BridgeToken token) {
         return mOrbLibraryCallback.getPreferredSubtitleLanguage();
+    }
+
+    /**
+     * Get preferred languages to be used for subtitles on this system.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return Comma separated string of languages (IETF BCP47 codes), in order of preference.
+     */
+    @Override
+    protected String Configuration_getPreferredSubtitleLanguage47(BridgeToken token) {
+        return mOrbLibraryCallback.getPreferredSubtitleLanguage47();
     }
 
     /**

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSessionCallback.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/IOrbSessionCallback.java
@@ -147,11 +147,33 @@ public interface IOrbSessionCallback {
     String getPreferredAudioLanguage();
 
     /**
+     * @since 204
+     *
+     * Gets a string containing languages to be used for audio playback, in order of preference.
+     *
+     * @return Comma separated string of languages (IETF BCP47 codes)
+     */
+    default String getPreferredAudioLanguage47() {
+        throw new UnsupportedOperationException("Unsupported 204 API.");
+    }
+
+    /**
      * Gets a string containing languages to be used for subtitles, in order of preference.
      *
      * @return Comma separated string of languages (ISO 639-2 codes)
      */
     String getPreferredSubtitleLanguage();
+
+    /**
+     * @since 204
+     *
+     * Gets a string containing languages to be used for subtitles, in order of preference.
+     *
+     * @return Comma separated string of languages (IETF BCP47 codes)
+     */
+    default String getPreferredSubtitleLanguage47() {
+        throw new UnsupportedOperationException("Unsupported 204 API.");
+    }
 
     /**
      * Gets a string containing languages to be used for the UI, in order of preference.

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
@@ -1020,6 +1020,15 @@ public abstract class AbstractBridge {
     protected abstract String Configuration_getPreferredAudioLanguage(BridgeToken token);
 
     /**
+     * Get preferred languages to be used for audio playback on this system.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return Comma separated string of languages (IETF BCP47 codes), in order of preference.
+     */
+    protected abstract String Configuration_getPreferredAudioLanguage47(BridgeToken token);
+
+    /**
      * Get preferred languages to be used for subtitles on this system.
      *
      * @param token The token associated with this request.
@@ -1027,6 +1036,15 @@ public abstract class AbstractBridge {
      * @return Comma separated string of languages (ISO 639-2 codes), in order of preference.
      */
     protected abstract String Configuration_getPreferredSubtitleLanguage(BridgeToken token);
+
+    /**
+     * Get preferred languages to be used for subtitles on this system.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return Comma separated string of languages (IETF BCP47 codes), in order of preference.
+     */
+    protected abstract String Configuration_getPreferredSubtitleLanguage47(BridgeToken token);
 
     /**
      * Get preferred languages to be used for the user-interface on this system.
@@ -1826,8 +1844,24 @@ public abstract class AbstractBridge {
                 break;
             }
 
+            case "Configuration.getPreferredAudioLanguage47": {
+                String result = Configuration_getPreferredAudioLanguage47(
+                        token
+                );
+                response.put("result", result);
+                break;
+            }
+
             case "Configuration.getPreferredSubtitleLanguage": {
                 String result = Configuration_getPreferredSubtitleLanguage(
+                        token
+                );
+                response.put("result", result);
+                break;
+            }
+
+            case "Configuration.getPreferredSubtitleLanguage47": {
+                String result = Configuration_getPreferredSubtitleLanguage47(
                         token
                 );
                 response.put("result", result);

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1076,6 +1076,19 @@ hbbtv.bridge.configuration = (function() {
     };
 
     /**
+     * Get preferred languages to be used for audio playback on this system.
+     *
+     * @return {string} Comma separated string of languages (IETF BCP47 codes), in order of
+     *    preference.
+     *
+     * @method
+     * @memberof bridge.configuration#
+     */
+    exported.getPreferredAudioLanguage47 = function() {
+        return hbbtv.native.request('Configuration.getPreferredAudioLanguage47').result;
+    };
+
+    /**
      * Get preferred languages to be used for the user-interface on this system.
      *
      * @return {string} Comma separated string of languages (ISO 639-2 codes), in order of
@@ -1086,6 +1099,19 @@ hbbtv.bridge.configuration = (function() {
      */
     exported.getPreferredSubtitleLanguage = function() {
         return hbbtv.native.request('Configuration.getPreferredSubtitleLanguage').result;
+    };
+
+    /**
+     * Get preferred languages to be used for the user-interface on this system.
+     *
+     * @return {string} Comma separated string of languages (IETF BCP47 codes), in order of
+     *    preference.
+     *
+     * @method
+     * @memberof bridge.configuration#
+     */
+    exported.getPreferredSubtitleLanguage47 = function() {
+        return hbbtv.native.request('Configuration.getPreferredSubtitleLanguage47').result;
     };
 
     /**

--- a/src/objects/configuration/configuration.js
+++ b/src/objects/configuration/configuration.js
@@ -21,8 +21,11 @@ hbbtv.objects.Configuration = (function() {
 
     hbbtv.utils.defineGetterProperties(prototype, {
         preferredAudioLanguage: hbbtv.bridge.configuration.getPreferredAudioLanguage,
-        preferredAudioLanguage47: hbbtv.bridge.configuration.getPreferredAudioLanguage,
+        // preferredAudioLanguage47 only supported since 2.0.4
+        preferredAudioLanguage47: hbbtv.bridge.configuration.getPreferredAudioLanguage47,
         preferredSubtitleLanguage: hbbtv.bridge.configuration.getPreferredSubtitleLanguage,
+        // preferredSubtitleLanguage47 only supported since 2.0.4
+        preferredSubtitleLanguage47: hbbtv.bridge.configuration.getPreferredSubtitleLanguage47,
         preferredUILanguage: hbbtv.bridge.configuration.getPreferredUILanguage,
         countryId: hbbtv.bridge.configuration.getCountryId,
         subtitlesEnabled: hbbtv.bridge.configuration.getSubtitlesEnabled,


### PR DESCRIPTION
to configuration

- add preferredAudioLanguage47 with bridge method
- add preferredSubtitleLanguage47 with bridge method
- add exception handling for preferredAudioLanguage47 and preferredSubtitleLanguage47

Testing:
- manual check

Note:
Considering the two methods specific for 204 and called by the bridges,
default handling and exceptions are set in IOrbSessionCallback.
Thus, in 204, they would works normally; 
in 203, they would threw exceptions as the bridge requests are called. 
However, they would be undefined values if anyone is going to make use of these two parameters in 203.
Not sure whether I should do anything else in configuration.js