### PR TITLE
Do not reset the broadcast playback for the iPlayer (BBC) app

### DIFF
--- a/components/application_manager/application_manager.cpp
+++ b/components/application_manager/application_manager.cpp
@@ -703,7 +703,8 @@ void ApplicationManager::OnApplicationPageChanged(uint16_t appId, const std::str
     if (m_app.isRunning && m_app.id == appId)
     {
         m_app.loadedUrl = url;
-        if (!Utils::IsInvalidDvbTriplet(m_currentService))
+        if (!Utils::IsInvalidDvbTriplet(m_currentService) && 
+            url.find("https://www.live.bbctvapps.co.uk/tap/iplayer") == std::string::npos)
         {
             // For broadcast-related applications we reset the broadcast presentation on page change,
             // as dead JS objects may have suspended presentation, set the video rectangle or set


### PR DESCRIPTION
Description:
The BBC application performs the transition from BR to BI mode by incorrectly using the vbo.stop() method instead of vbo.setChannel(null). Whitelist the BBC IPlayer application from resetting the broadcast object, to treat it as a BI app.

Tests:
BBC IPlayer launch