### PR TITLE
Set enumerable on KeySet

### DIFF
--- a/src/polyfill/keyevent.js
+++ b/src/polyfill/keyevent.js
@@ -52,6 +52,7 @@
             Object.defineProperty(window.KeyEvent, key, {
                 value: keys[key],
                 writable: false,
+                enumerable: true,
             });
         }
     }


### PR DESCRIPTION
Description:
BBC TC29 requires to iterate in the KeySet object. Set the enumerable property to true so that we can enable that.

Tests:
TC29