### PR TITLE
COD-36 support for high resolution graphics

### DIFF
--- a/android/mock204app/src/main/java/org/orbtv/mock204app/MockAit.java
+++ b/android/mock204app/src/main/java/org/orbtv/mock204app/MockAit.java
@@ -27,6 +27,7 @@ class MockAit {
         public String name;
         public String baseUrl;
         public String initialPath;
+        public Vector<Integer> graphics;
     }
 
     private final Vector<Byte> bytes = new Vector<>();
@@ -37,8 +38,8 @@ class MockAit {
 
         int appLoopLength = 0;
         for (MockAit.Application application : applications) {
-            appLoopLength += 35 + application.name.length() + application.baseUrl.length() +
-                    application.initialPath.length();
+            appLoopLength += 38 + application.name.length() + application.baseUrl.length() +
+                    application.initialPath.length() + application.graphics.size();
         }
 
         insert(0x74, 8); // table_id
@@ -60,8 +61,8 @@ class MockAit {
 
         // applications
         for (MockAit.Application application : applications) {
-            int descLoopLength = 26 + application.name.length() + application.baseUrl.length() +
-                    application.initialPath.length();
+            int descLoopLength = 29 + application.name.length() + application.baseUrl.length() +
+                    application.initialPath.length() + application.graphics.size();
 
             insert(application.orgId, 32); // application_identifier/organisation_id
             insert(application.id, 16); // application_identifier/application_id
@@ -111,6 +112,17 @@ class MockAit {
             insert(application.initialPath.length(), 8); // descriptor_length
             for (char ch : application.initialPath.toCharArray()) {
                 insert(ch, 8);
+            }
+
+            // graphics_constraints_descriptor
+            insert(0x14, 8); // descriptor_tag
+            insert(1 + application.graphics.size(), 8); // descriptor_length
+            insert(0b11111, 5); // reserved_future_use
+            insert(0, 1); // can_run_without_visible_ui
+            insert(0, 1); // handles_configuration_changed
+            insert(0, 1); // handles_externally_controlled_video
+            for (Integer i : application.graphics) {
+                insert(i, 8);  // graphics_configuration_byte
             }
         }
 

--- a/android/mock204app/src/main/java/org/orbtv/mock204app/TestSuiteScenario.java
+++ b/android/mock204app/src/main/java/org/orbtv/mock204app/TestSuiteScenario.java
@@ -228,6 +228,13 @@ public class TestSuiteScenario {
             application.baseUrl = info.getString("baseUrl").replace("$LOCALHOST",
                     mLocalHost);
             application.initialPath = info.getString("initialPath");
+            application.graphics = new Vector<>();
+            if (info.has("graphics")) {
+                JSONArray graphics = info.getJSONArray("graphics");
+                for (int j = 0; j < graphics.length(); ++j) {
+                    application.graphics.add(graphics.getInt(j));
+                }
+            }
             parsed.add(application);
         }
         return parsed;

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/ApplicationManager.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/ApplicationManager.java
@@ -46,8 +46,11 @@ class ApplicationManager {
          *
          * @param appId The application ID.
          * @param entryUrl The entry page URL.
+         *
+         * @since 204
+         * @param graphics The list of the co-ordinate graphics supported by the application
          */
-        void loadApplication(int appId, String entryUrl);
+        void loadApplication(int appId, String entryUrl, int[] graphics);
 
         /**
          * Tell the browser to show the application.
@@ -275,12 +278,12 @@ class ApplicationManager {
         }
     }
 
-    private void jniCbLoadApplication(int appId, String entryUrl) {
+    private void jniCbLoadApplication(int appId, String entryUrl, int[] graphics) {
         synchronized (mLock) {
             m_entryUrl = entryUrl;
             if (mSessionCallback != null) {
                 mSessionCallback.resetBroadcastPresentation();
-                mSessionCallback.loadApplication(appId, entryUrl);
+                mSessionCallback.loadApplication(appId, entryUrl, graphics);
                 if (m_entryUrl.equals(NOT_STARTED_URL)) {
                     mSessionCallback.notifyApplicationStatusChanged(
                             IOrbSessionCallback.ApplicationStatus.NOT_STARTED);

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/BrowserView.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/BrowserView.java
@@ -252,7 +252,7 @@ class BrowserView extends WebView {
         } else if (resolution <= 1080) {
             mAppWidth = 1920;
         } else {
-            mAppWidth = 3480;
+            mAppWidth = 3840;
         }
         updateScale();
     }

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/BrowserView.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/BrowserView.java
@@ -190,11 +190,12 @@ class BrowserView extends WebView {
         }
     }
 
-    public void loadApplication(int appId, String entryUrl) {
+    public void loadApplication(int appId, String entryUrl, int[] graphicsConfigIds) {
         mLoadAppId = appId;
         mContext.getMainExecutor().execute(() -> {
             mAppId = appId;
             loadUrl(entryUrl);
+            updateAppResolution(graphicsConfigIds);
             if (entryUrl.equals("about:blank")) {
                 setHiddenFlag(PAGE_HIDDEN_FLAG);
             } else {
@@ -237,6 +238,23 @@ class BrowserView extends WebView {
             Log.d(TAG, "Set scale to " + scale);
             setInitialScale(scale);
         });
+    }
+
+    private void updateAppResolution(int[] graphicsConfigIds) {
+        int resolution = 720;
+        if (graphicsConfigIds != null && graphicsConfigIds.length != 0) {
+            Arrays.sort(graphicsConfigIds);
+            resolution = graphicsConfigIds[graphicsConfigIds.length -1];
+        }
+        Log.d(TAG, "Rendering resolution is set to " + resolution + "p");
+        if (resolution <= 720) {
+            mAppWidth = 1280;
+        } else if (resolution <= 1080) {
+            mAppWidth = 1920;
+        } else {
+            mAppWidth = 3480;
+        }
+        updateScale();
     }
 
     private void setHiddenFlag(int flag) {
@@ -345,7 +363,7 @@ class BrowserView extends WebView {
         /**
          * Check whether the key code is in the key set of the application.
          *
-         * @param appId The application ID.
+         * @param appId   The application ID.
          * @param keyCode A TvBrowserTypes.VK_* key code.
          * @return true if it is in the key set, otherwise false
          */
@@ -363,7 +381,7 @@ class BrowserView extends WebView {
          * loaded. For example, when the user follows a link.
          *
          * @param appId The application ID.
-         * @param url The URL of the new page.
+         * @param url   The URL of the new page.
          */
         void notifyApplicationPageChanged(int appId, String url);
     }

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/OrbSession.java
@@ -62,10 +62,17 @@ class OrbSession implements IOrbSession {
              *
              * @param appId The application ID.
              * @param entryUrl The entry page URL.
+             *
+             * @since 204
+             * @param graphics The list of the co-ordinate graphics supported by the application
              */
             @Override
-            public void loadApplication(int appId, String entryUrl) {
-                mBrowserView.loadApplication(appId, entryUrl);
+            public void loadApplication(int appId, String entryUrl, int[] graphics) {
+                if (mOrbHbbTVVersion >= 204) {
+                    mBrowserView.loadApplication(appId, entryUrl, graphics);
+                } else {
+                    mBrowserView.loadApplication(appId, entryUrl, null);
+                }
             }
 
             /**

--- a/components/application_manager/ait.h
+++ b/components/application_manager/ait.h
@@ -160,6 +160,7 @@ public:
         uint8_t usageType;
         std::vector<std::string> boundaries;
         std::vector<S_APP_PARENTAL_RATING> parentalRatings;
+        std::vector<uint16_t> graphicsConstraints;
         std::string scheme;
     } S_AIT_APP_DESC;
 
@@ -308,6 +309,8 @@ private:
     static void ParseSimpleAppBoundaryDesc(const uint8_t *dataPtr, S_AIT_APP_DESC *appPtr);
 
     static void ParseParentalRatingDesc(const uint8_t *dataPtr, S_AIT_APP_DESC *appPtr);
+
+    static void ParseGraphicsConstraints(const uint8_t *dataPtr, S_AIT_APP_DESC *appPtr);
 
     /**
      *

--- a/components/application_manager/app.cpp
+++ b/components/application_manager/app.cpp
@@ -68,6 +68,7 @@ App App::CreateAppFromAitDesc(const Ait::S_AIT_APP_DESC *desc,
     app.controlCode = desc->controlCode;
     app.orgId = desc->orgId;
     app.appId = desc->appId;
+    app.graphicsConstraints = desc->graphicsConstraints;
 
     app.keySetMask = 0;
 

--- a/components/application_manager/app.h
+++ b/components/application_manager/app.h
@@ -72,6 +72,7 @@ public:
     bool isActivated = true;
     uint16_t id;
     std::vector<Ait::S_APP_PARENTAL_RATING> parentalRatings;
+    std::vector<uint16_t> graphicsConstraints;
     uint8_t versionMinor;
 private:
     std::string m_scheme;

--- a/components/application_manager/application_manager.cpp
+++ b/components/application_manager/application_manager.cpp
@@ -959,7 +959,8 @@ bool ApplicationManager::RunApp(const App &app)
             }
         }
 
-        m_sessionCallback->LoadApplication(m_app.id, m_app.entryUrl.c_str());
+        m_sessionCallback->LoadApplication(m_app.id, m_app.entryUrl.c_str(),
+            m_app.graphicsConstraints.size(), m_app.graphicsConstraints);
 
         if (!m_app.isHidden)
         {

--- a/components/application_manager/application_manager.h
+++ b/components/application_manager/application_manager.h
@@ -57,6 +57,18 @@ public:
         virtual void LoadApplication(uint16_t appId, const char *entryUrl) = 0;
 
         /**
+         * Tell the browser to load an application. If the entry page fails to load, the browser
+         * should call ApplicationManager::OnLoadApplicationFailed.
+         *
+         * @param appId The application ID.
+         * @param entryUrl The entry page URL.
+         * @param size The number of the co-ordinate graphics
+         * @param graphics The list of the co-ordinate graphics supported by the application
+         */
+        virtual void LoadApplication(uint16_t appId, const char *entryUrl, int size, const
+            std::vector<uint16_t> graphics) = 0;
+
+        /**
          * Tell the browser to show the loaded application.
          */
         virtual void ShowApplication() = 0;

--- a/components/application_manager/xml_parser.cpp
+++ b/components/application_manager/xml_parser.cpp
@@ -472,6 +472,51 @@ static void XmlParseAppDescProfile(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr
  * @param node
  * @param app_ptr
  */
+static void XmlParseAppDescGraphics(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr)
+{
+    const xmlChar *cptr;
+    xmlChar *dptr;
+
+    node = node->xmlChildrenNode;
+    app_ptr->graphicsConstraints.push_back(720);
+    while (node != nullptr)
+    {
+        if (node->type == XML_ELEMENT_NODE)
+        {
+            cptr = node->name;
+            if (xmlStrEqual(cptr, (const xmlChar *)"GraphicsConfiguration"))
+            {
+                NODE_CONTENT_GET(node, dptr);
+                if (dptr)
+                {
+                    if (xmlStrEqual(dptr, (const
+                                           xmlChar *)"urn:hbbtv:graphics:resolution:1920x1080"))
+                    {
+                        app_ptr->graphicsConstraints.push_back(1080);
+                    }
+                    else if (xmlStrEqual(dptr, (const
+                                                xmlChar *)"urn:hbbtv:graphics:resolution:3840x2160"))
+                    {
+                        app_ptr->graphicsConstraints.push_back(2160);
+                    }
+                    else if (xmlStrEqual(dptr, (const
+                                                xmlChar *)"urn:hbbtv:graphics:resolution:7680x4320"))
+                    {
+                        app_ptr->graphicsConstraints.push_back(4320);
+                    }
+                    NODE_CONTENT_RELEASE();
+                }
+            }
+        }
+        node = node->next;
+    }
+}
+
+/**
+ *
+ * @param node
+ * @param app_ptr
+ */
 static void XmlParseAppDesc(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr)
 {
     const xmlChar *cptr;
@@ -537,6 +582,10 @@ static void XmlParseAppDesc(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr)
                 }
                 pr.value = (uint8_t)XmlGetContentInt(node);
                 app_ptr->parentalRatings.push_back(pr);
+            }
+            else if (xmlStrEqual(cptr, (const xmlChar *)"GraphicsConstraints"))
+            {
+                XmlParseAppDescGraphics(node, app_ptr);
             }
         }
         node = node->next;

--- a/components/application_manager/xml_parser.cpp
+++ b/components/application_manager/xml_parser.cpp
@@ -854,6 +854,9 @@ static void XmlParseApplication(xmlNodePtr node, Ait::S_AIT_APP_DESC *app_ptr)
                     XmlParseAppLocation(node, app_ptr);
                 }
             }
+            else if (xmlStrEqual(cptr, (const xmlChar *)"GraphicsConstraints")) {
+                XmlParseAppDescGraphics(node, app_ptr);
+            }
         }
         node = node->next;
     }

--- a/tests/debug/json_rpc/scenario.json
+++ b/tests/debug/json_rpc/scenario.json
@@ -10,7 +10,8 @@
                "orgId": 1,
                "name": "example",
                "baseUrl": "$LOCALHOST/debug/json_rpc/",
-               "initialPath": "index.html"
+               "initialPath": "index.html",
+               "graphics": [3]
             }
          ]
       }

--- a/tests/launchers/mitxperts/scenario.json
+++ b/tests/launchers/mitxperts/scenario.json
@@ -10,7 +10,8 @@
                "orgId": 19,
                "name": "HbbTV-Testsuite",
                "baseUrl": "http://itv.mit-xperts.com/hbbtvtest/",
-               "initialPath": "index.php"
+               "initialPath": "index.php",
+               "graphics": [3]
             },
             {
                "id": 501,


### PR DESCRIPTION
COD-64 add graphicsConstraints in ait and xml ait
- parse graphicsConstraints in ait and xml ait
- update app
- update scenario file

COD-65 update graphics info in application manager and browserView
- send graphics info to the callback of application manager
- graphics info is only active when OrbHbbTVVersion >= 204
- scale the browserView based on the highest supported resolution

Testing:
- manual checking with mit-xpert
https://github.com/OceanBlueSoftware/mitxp-testsuite/pull/3
when OrbHbbTVVersion >= 204, scaling browserView based on the supported resolution;
in other cases, scaling to default app size (1280x720)