### PR TITLE
Sliding window for seekable update. Support for buffered

### DIFF
--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -565,28 +565,15 @@ hbbtv.objects.DashProxy = (function() {
         p.periods = e.data.Period_asArray;
         p.mrsUrl = e.data.mrsUrl;
         p.ciAncillaryData = e.data.ciAncillaryData;
-
-        // dispatch __orb_timeShiftBufferDepthReceived__ event for seekable property in case of rdk native
-        if (hbbtv.native.name === 'rdk') {
-            const timeShiftEvt = new Event('__orb_timeShiftBufferDepthReceived__');
-            if (e.data.hasOwnProperty('timeShiftBufferDepth')) {
-                Object.assign(timeShiftEvt, {
-                    timeShiftBufferDepth: e.data.timeShiftBufferDepth,
-                });
-            } else {
-                Object.assign(timeShiftEvt, {
-                    firstPeriodStart: e.data.Period_asArray[0].start,
-                });
-            }
-
-            this.dispatchEvent(timeShiftEvt);
-        }
-
+        
         const evt = new Event('__orb_startDateUpdated__');
         Object.assign(evt, {
             startDate: Date.parse(e.data.availabilityStartTime),
         });
         this.dispatchEvent(evt);
+        
+        hbbtv.native.dispatchManifestNativeEvents?.(e);
+
         console.log(
             'manifest availability start time:',
             e.data.availabilityStartTime,
@@ -703,6 +690,7 @@ hbbtv.objects.DashProxy = (function() {
                     },
                 },
             });
+            hbbtv.native.setDashProxy(this);
             p.player.initialize(this, src, false);
             p.player.on('error', p.onError);
             p.player.on('manifestLoaded', p.onManifestLoaded);

--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -18,7 +18,6 @@ hbbtv.mediaManager = (function() {
     let objectHandlers = {};
     let fallbackHandlers = undefined;
     let mediaType = undefined;
-    let rdk__orb_timeShiftBufferDepthReceived = undefined;
 
     const mediaProxy = hbbtv.objects.createIFrameObjectProxy();
     window.orbNetwork = {

--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -18,6 +18,8 @@ hbbtv.mediaManager = (function() {
     let objectHandlers = {};
     let fallbackHandlers = undefined;
     let mediaType = undefined;
+    let rdk__orb_timeShiftBufferDepthReceived = undefined;
+
     const mediaProxy = hbbtv.objects.createIFrameObjectProxy();
     window.orbNetwork = {
         resolveHostAddress: (hostname) =>
@@ -360,15 +362,48 @@ hbbtv.mediaManager = (function() {
             mediaProxy.dispatchEvent(MEDIA_PROXY_ID, e);
         };
 
-        const updateSeekablePeriod = function(e) {
+        const updateSeekableRdk = function(data) {
             const ranges = [];
-            ranges.push({
-                start: e.firstPeriodStart,
-                end: media.currentTime,
-            });
+
+            for (let i = 0; i < media.seekable.length; ++i) {
+                const seekableEnd = media.seekable.end(i);
+
+                /**
+                 * call with MPD@timeShiftBufferDepth set. Will need to adjust
+                 * the seekable ranges so that the diff is not exceeding timeShiftBufferDepth.
+                 * Progress seekableStart accordingly
+                 */
+                if (data.hasOwnProperty('timeShiftBufferDepth')) {
+                    let seekableStart = media.seekable.start(i);
+                    if (seekableEnd - media.seekable.start(i) > data.timeShiftBufferDepth) {
+                        seekableStart = seekableEnd - data.timeShiftBufferDepth;
+                    }
+                    ranges.push({
+                        start: seekableStart,
+                        end: seekableEnd,
+                    });
+                }
+                /**
+                 * The seekable parameter reflected the removal of a period when MPD@timeShiftBufferDepth is not present
+                 * MPD@timeShiftBufferDepth was not present and MPD@type was dynamic.
+                 * The seekable start should be equal to the removed period duration.
+                 */
+                else if (data.hasOwnProperty('firstPeriodStart')){
+                    ranges.push({
+                        start: data.firstPeriodStart,
+                        end: media.currentTime,
+                    });
+                }
+                else {
+                    ranges.push({
+                        start: media.seekable.start(i),
+                        end: media.seekable.end(i),
+                    }); 
+                }
+            }
 
             mediaProxy.callObserverMethod(MEDIA_PROXY_ID, 'setSeekable', [ranges]);
-            mediaProxy.dispatchEvent(MEDIA_PROXY_ID, e);
+            mediaProxy.dispatchEvent(MEDIA_PROXY_ID, data);
         };
 
         const updateBuffered = function(e) {
@@ -427,28 +462,18 @@ hbbtv.mediaManager = (function() {
         );
 
         // in case of dynamic mpd, update the seekable property based on timeupdate
-        // remove the handling after MPD@timeShiftBufferDepth seconds passed, since dash
-        // updates the seekable property continuously. Use this in case of rdk.
+        // dashjs will update the seekable property based on the dvr property continuously.
+        // we will need to filter the diff and see if it exceeds MPD@timeShiftBufferDepth
         if (hbbtv.native.name === 'rdk') {
             media.addEventListener('__orb_timeShiftBufferDepthReceived__', (e) => {
-                const data = e;
-                if (data.hasOwnProperty('timeShiftBufferDepth')) {
-                    media.addEventListener('timeupdate', updateSeekable);
-                    setTimeout(() => {
-                        media.removeEventListener('timeupdate', updateSeekable);
-                    }, (e.timeShiftBufferDepth - 1) * 1000);
-                } else {
-                    media.addEventListener('timeupdate', () => {
-                        updateSeekablePeriod(data);
-                    });
-                }
+                rdk__orb_timeShiftBufferDepthReceived = e;
             });
         }
 
         media.addEventListener('play', (e) => {
             // some tests ask for the seekable property just after the playing event
             if (hbbtv.native.name === 'rdk') {
-                updateSeekable(e);
+                updateSeekableRdk(e);
             }
             let evt = new Event('__orb_onplayspeedchanged__');
             Object.assign(evt, {
@@ -489,6 +514,13 @@ hbbtv.mediaManager = (function() {
         });
         media.addEventListener('progress', updateSeekable);
         media.addEventListener('progress', updateBuffered);
+
+        // Use the timeupdate in case of rdk client, as webkit does not support the progress event at mse
+        if (hbbtv.native.name === 'rdk') {
+            media.addEventListener('timeupdate', () => { updateSeekableRdk(rdk__orb_timeShiftBufferDepthReceived); });
+            media.addEventListener('timeupdate', updateBuffered);
+        } 
+ 
         media.addEventListener('timeupdate', makeCallback('currentTime'));
         media.addTextTrack = function() {
             return textTracks.orb_addTextTrack.apply(textTracks, arguments);

--- a/src/natives/android.js
+++ b/src/natives/android.js
@@ -16,8 +16,22 @@
 
 hbbtv.native = {
     name: 'android',
+    media: undefined,
+    mediaProxy: undefined,
+    dashProxy: undefined,
+
     initialise: function() {
         this.token = Object.assign({}, document.token);
+    },
+    // setters
+    setMedia: function(media) {
+        this.media = media;
+    },
+    setMediaProxy: function(mediaProxy) {
+        this.mediaProxy = mediaProxy;
+    },
+    setDashProxy: function(dashProxy) {
+        this.dashProxy = dashProxy;
     },
     request: function(method, params) {
         const body = {
@@ -74,4 +88,27 @@ hbbtv.native = {
         }
         return false;
     },
+    // Polling events
+    getSeekablePollingEvent: function() {
+        return 'progress';
+    },
+    getBufferedPollingEvent: function() {
+        return 'progress';
+    },
+     // Event handlers
+    updateSeekable: function(e) {
+        const ranges = [];
+        const media = this.media;
+        const mediaProxy = this.mediaProxy;
+        const MEDIA_PROXY_ID = 'HTMLMediaElement';
+
+        for (let i = 0; i < media.seekable.length; ++i) {
+            ranges.push({
+                start: media.seekable.start(i),
+                end: media.seekable.end(i),
+            });
+        }
+        mediaProxy.callObserverMethod(MEDIA_PROXY_ID, 'setSeekable', [ranges]);
+        mediaProxy.dispatchEvent(MEDIA_PROXY_ID, e);
+    }
 };

--- a/src/natives/rdk.js
+++ b/src/natives/rdk.js
@@ -1,8 +1,28 @@
 // RDK/Linux native
 hbbtv.native = {
     name: 'rdk',
+    media: undefined,
+    mediaProxy: undefined,
+    dashProxy: undefined,
+    orb_timeShiftBufferDepthReceived: undefined,
     initialise: function() {
         this.token = Object.assign({}, document.token);
+    },
+    // setters
+    setMedia: function(media) {
+        console.log('[RDK-Native::setMedia]');
+        console.log(media);
+        this.media = media;
+    },
+    setMediaProxy: function(mediaProxy) {
+        console.log('[RDK-Native::setMediaProxy]');
+        console.log(mediaProxy);
+        this.mediaProxy = mediaProxy;
+    },
+    setDashProxy: function(dashProxy) {
+        console.log('[RDK-Native::setDashProxy]');
+        console.log(dashProxy);
+        this.dashProxy = dashProxy;
     },
     request: function(method, params) {
         const body = {
@@ -41,4 +61,90 @@ hbbtv.native = {
         }
         return false;
     },
+    // optional methdod to add native specific event listeners on mediamanager
+    addMediaNativeListeners: function() {
+        console.log('[RDK-Native::addMediaNativeListeners] Adding media native listeners');
+        // in case of dynamic mpd, update the seekable property based on timeupdate
+        // dashjs will update the seekable property based on the dvr property continuously.
+        // we will need to filter the diff and see if it exceeds MPD@timeShiftBufferDepth
+        this.media.addEventListener('__orb_timeShiftBufferDepthReceived__', (e) => {
+            console.log('[RDK-Native::__orb_timeShiftBufferDepthReceived__]');
+            this.orb_timeShiftBufferDepthReceived = e;
+        });
+        console.log('[RDK-Native::addMediaNativeListeners] Added __orb_timeShiftBufferDepthReceived__ listener');
+    },
+
+    // optional method to dispatch native specific events from dashproxy
+    dispatchManifestNativeEvents: function(e) {
+        // dispatch __orb_timeShiftBufferDepthReceived__ event for seekable property in case of rdk native
+        const timeShiftEvt = new Event('__orb_timeShiftBufferDepthReceived__');
+        if (e.data.hasOwnProperty('timeShiftBufferDepth')) {
+            Object.assign(timeShiftEvt, {
+                timeShiftBufferDepth: e.data.timeShiftBufferDepth,
+            });
+        } else {
+            Object.assign(timeShiftEvt, {
+                firstPeriodStart: e.data.Period_asArray[0].start,
+            });
+        }
+        console.log('[RDK-Native] Dipsatching __orb_timeShiftBufferDepthReceived__');
+        this.dashProxy.dispatchEvent(timeShiftEvt);
+    },
+
+    // Polling events
+    getSeekablePollingEvent: function() {
+        return 'timeupdate';
+    },
+    getBufferedPollingEvent: function() {
+        return 'timeupdate';
+    },
+
+    // Event handlers
+    updateSeekable: function(e) {
+        const ranges = [];
+        const media = this.media;
+        const mediaProxy = this.mediaProxy;
+        const MEDIA_PROXY_ID = 'HTMLMediaElement';
+        const data = this.orb_timeShiftBufferDepthReceived;
+
+        for (let i = 0; i < media.seekable.length; ++i) {
+            const seekableEnd = media.seekable.end(i);
+
+            /**
+             * call with MPD@timeShiftBufferDepth set. Will need to adjust
+             * the seekable ranges so that the diff is not exceeding timeShiftBufferDepth.
+             * Progress seekableStart accordingly
+             */
+            if (data !== undefined && data.hasOwnProperty('timeShiftBufferDepth')) {
+                let seekableStart = media.seekable.start(i);
+                if (seekableEnd - media.seekable.start(i) > data.timeShiftBufferDepth) {
+                    seekableStart = seekableEnd - data.timeShiftBufferDepth;
+                }
+                ranges.push({
+                    start: seekableStart,
+                    end: seekableEnd,
+                });
+            }
+            /**
+             * The seekable parameter reflected the removal of a period when MPD@timeShiftBufferDepth is not present
+             * MPD@timeShiftBufferDepth was not present and MPD@type was dynamic.
+             * The seekable start should be equal to the removed period duration.
+             */
+            else if (data !== undefined && data.hasOwnProperty('firstPeriodStart')){
+                ranges.push({
+                    start: data.firstPeriodStart,
+                    end: media.currentTime,
+                });
+            }
+            else {
+                ranges.push({
+                    start: media.seekable.start(i),
+                    end: media.seekable.end(i),
+                }); 
+            }
+        }
+
+        mediaProxy.callObserverMethod(MEDIA_PROXY_ID, 'setSeekable', [ranges]);
+        mediaProxy.dispatchEvent(MEDIA_PROXY_ID, data);
+    }
 };


### PR DESCRIPTION
Description
RDK seekable tests still fail. The difference on the seekable property exceeds the expected difference by a couple of milliseconds. Rework RDK approach so that it applies a sliding window for the seekable property, keeping it in the expected range (MPD@timeShiftBufferDepth).

Also add support for the buffered attribute by using the timeupdate on it.

Tests
org.hbbtv_HTML5-DASH016
org.hbbtv_HTML5-DASH017
org.hbbtv_HTML5-DASH020
org.hbbtv_HTML5-DASH023
org.hbbtv_HTML5-DASH025
org.hbbtv_HTML5-DASH034
org.hbbtv_HTML50080