### PR TITLE
Fix for org.hbbtv_HTML5-DASH026 and org.hbbtv_HTML5-DASH026

### DIFF
--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -349,17 +349,6 @@ hbbtv.mediaManager = (function() {
             mediaProxy.dispatchEvent(MEDIA_PROXY_ID, e);
             console.log('iframe: update properties', e.type, props);
         };
-        const updateSeekable = function(e) {
-            const ranges = [];
-            for (let i = 0; i < media.seekable.length; ++i) {
-                ranges.push({
-                    start: media.seekable.start(i),
-                    end: media.seekable.end(i),
-                });
-            }
-            mediaProxy.callObserverMethod(MEDIA_PROXY_ID, 'setSeekable', [ranges]);
-            mediaProxy.dispatchEvent(MEDIA_PROXY_ID, e);
-        };
 
         const updateBuffered = function(e) {
             const ranges = [];

--- a/src/natives/rdk.js
+++ b/src/natives/rdk.js
@@ -144,6 +144,19 @@ hbbtv.native = {
             }
         }
 
+        /**
+         * Cover cases where the MPD is dynamic and the media element is paused until the start is greater than currentTime.
+         * In this case, an error event should be generated of type MEDIA_ERR_NETWORK (error.code = 2). DashProxy will dispatch
+         * this error event.
+         */
+        if (this.media.currentTime < ranges[0].start) {
+            const e = new Event('error');
+            e.error = {}; 
+            e.error.code = 2;
+            e.error.message = '';
+            this.dashProxy.dispatchEvent(e);
+        }
+        // console.log(`[RDK-NATIVE::updateSeekable] ${ranges[0].start} ${ranges[0].end}`);
         mediaProxy.callObserverMethod(MEDIA_PROXY_ID, 'setSeekable', [ranges]);
         mediaProxy.dispatchEvent(MEDIA_PROXY_ID, data);
     }


### PR DESCRIPTION
Description
Modify updateSeekable of rdk native, to check for current time and throw network error in case it is outside the seekable window.

Tests
org.hbbtv_HTML5-DASH026
org.hbbtv_HTML5-DASH027 