### PR TITLE
DASHEvent id property is lowercase. Id was a typo.

### DIFF
--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeTypes.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeTypes.java
@@ -1169,13 +1169,13 @@ public class BridgeTypes {
     }
 
     public static class DASHEvent implements JSONSerializable {
-        public String Id;
+        public String id;
         public double startTime;
         public double duration;
         public String contentEncoding;
 
-        public DASHEvent(String Id, double startTime, double duration, String contentEncoding) {
-            this.Id = Id;
+        public DASHEvent(String id, double startTime, double duration, String contentEncoding) {
+            this.id = id;
             this.startTime = startTime;
             this.duration = duration;
             this.contentEncoding = contentEncoding;
@@ -1184,11 +1184,11 @@ public class BridgeTypes {
         @Override
         public JSONObject toJSONObject() throws JSONException {
             JSONObject o = new JSONObject();
-            if (Id != null) {
-                o.put("Id", Id);
+            if (id != null) {
+                o.put("id", id);
             }
             else {
-                o.put("Id", "");
+                o.put("id", "");
             }
             if (contentEncoding != null) {
                 o.put("contentEncoding", contentEncoding);

--- a/src/objects/dashevent.js
+++ b/src/objects/dashevent.js
@@ -6,8 +6,8 @@ hbbtv.objects.DASHEvent = (function() {
         pauseOnExit() {
             return false;
         },
-        Id() {
-            return privates.get(this).eventData.Id || "";
+        id() {
+            return privates.get(this).eventData.id || "";
         },
         startTime() {
             return privates.get(this).eventData.startTime || 0;
@@ -22,7 +22,7 @@ hbbtv.objects.DASHEvent = (function() {
 
     // Initialise an instance of prototype
     function initialise(streamEvent) {
-        privates.set(this, { 
+        privates.set(this, {
             eventData: streamEvent.DASHEvent,
         });
         const data = streamEvent.text;


### PR DESCRIPTION
DASHEvent id property is lowercase. Id appearing in the specification was a typo:
https://redmine.hbbtv.org/issues/13576

This should fix org.hbbtv_DVBI_EVENTS0060 and org.hbbtv_DVBI_EVENTS0130