### PR TITLE
Add mediaManager resolveNetworkError api for errorreport tests

### DIFF
--- a/rdk/ORB/library/src/core/requestHandlers/NetworkRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/NetworkRequestHandler.cpp
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 #include "NetworkRequestHandler.h"
+#include "ORBEngine.h"
 
 #include <netdb.h>
 #include <arpa/inet.h>
 
 #define NETWORK_RESOLVE_HOST_ADDRESS "resolveHostAddress"
+#define NETWORK_RESOLVE_NETWORK_ERROR "resolveNetworkError"
 
 namespace orb {
 /**
@@ -62,6 +64,13 @@ bool NetworkRequestHandler::Handle(
         std::string hostName = params["hostname"];
         std::string hostAddress = ResolveHostAddress(hostName);
         response["result"] = hostAddress;
+    }
+    // Network.resolveNetworkError
+    else if (method == NETWORK_RESOLVE_NETWORK_ERROR)
+    {
+        std::string responseText = params.value("responseText", "");
+        std::string dashErrorCode = ORBEngine::GetSharedInstance().GetORBPlatform()->Network_ResolveNetworkError(responseText);
+        response["result"] = dashErrorCode;
     }
     // UnknownMethod
     else

--- a/rdk/ORB/library/src/platform/ORBPlatform.h
+++ b/rdk/ORB/library/src/platform/ORBPlatform.h
@@ -125,7 +125,13 @@ public:
     virtual bool Network_IsConnectedToInternet() = 0;
 
 
-
+    /**
+     * Resolves netrwork error by passing the response status text received.
+     * 
+     * @param responseText 
+     * @return std::string the dash DVBError code
+     */
+    virtual std::string Network_ResolveNetworkError(std::string responseText) = 0;
     /******************************************************************************
     ** Broadcast API
     *****************************************************************************/

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
@@ -199,6 +199,12 @@ bool ORBPlatformMockImpl::Network_IsConnectedToInternet()
     return true;
 }
 
+std::string Network_ResolveNetworkError(std::string responseText)
+{
+    ORB_LOG("%s", responseText.c_str());
+    return "unknown";
+}
+
 /******************************************************************************
 ** Broadcast API
 *****************************************************************************/

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
@@ -43,6 +43,8 @@ public:
     // Network api
     virtual bool Network_IsConnectedToInternet() override;
 
+    virtual std::string Network_ResolveNetworkError(std::string responseText) override;
+
     // Broadcast api
     virtual void Broadcast_SetVideoRectangle(int x, int y, int width, int height) override;
     virtual std::shared_ptr<Channel> Broadcast_GetCurrentChannel() override;

--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -25,6 +25,11 @@ hbbtv.mediaManager = (function() {
             hbbtv.native.request('Network.resolveHostAddress', {
                 hostname
             }).result,
+
+        resolveNetworkError: (responseText) =>
+            hbbtv.native.request('Network.resolveNetworkError', {
+                responseText
+            }).result,
     };
     window.orbParentalRating = {
         isRatingBlocked: (scheme, region, value) =>


### PR DESCRIPTION
Description
Addition of resolveNetworkError api to fix org.hbbtv_DASH-ERRORREP0006 and org.hbbtv_DASH-ERRORREP0007. This is an rdk specific change.

Tests:
org.hbbtv_DASH-ERRORREP0006
org.hbbtv_DASH-ERRORREP0007