### PR TITLE
HTM-807 dialogueEnhancementGainPreference shall be zero

### DIFF
--- a/android/mock204app/src/main/java/org/orbtv/mock204app/MockOrbSessionCallback.java
+++ b/android/mock204app/src/main/java/org/orbtv/mock204app/MockOrbSessionCallback.java
@@ -1943,19 +1943,21 @@ public class MockOrbSessionCallback implements IOrbSessionCallback {
     }
 
     private void querySettingDialogueEnhancement(int connection, String id, boolean isEnabled) {
-        // If DE is switched off, dialogueEnhancementGain shall be set to 0.
+        // If DE is switched off, dialogueEnhancementGain and dialogueEnhancementGainPreference shall be set to 0.
         int gain = isEnabled ? MOCK_DIALOGUE_ENHANCEMENT_GAIN : 0;
+        int gainPreference = isEnabled ? MOCK_DIALOGUE_ENHANCEMENT_GAIN_PREFERENCE : 0;
         mSession.onQueryDialogueEnhancement(connection, id,
-                MOCK_DIALOGUE_ENHANCEMENT_GAIN_PREFERENCE, gain,
+                gainPreference, gain,
                 MOCK_DIALOGUE_ENHANCEMENT_GAIN_LIMIT_MIN,
                 MOCK_DIALOGUE_ENHANCEMENT_GAIN_LIMIT_MAX);
     }
 
     private void notifyDialogueEnhancement(boolean isEnabled) {
-        // If DE is switched off, dialogueEnhancementGain shall be set to 0.
+        // If DE is switched off, dialogueEnhancementGain and dialogueEnhancementGainPreference shall be set to 0.
         int gain = isEnabled ? MOCK_DIALOGUE_ENHANCEMENT_GAIN : 0;
+        int gainPreference = isEnabled ? MOCK_DIALOGUE_ENHANCEMENT_GAIN_PREFERENCE : 0;
         mSession.onNotifyDialogueEnhancement(
-                MOCK_DIALOGUE_ENHANCEMENT_GAIN_PREFERENCE, gain,
+                gainPreference, gain,
                 MOCK_DIALOGUE_ENHANCEMENT_GAIN_LIMIT_MIN,
                 MOCK_DIALOGUE_ENHANCEMENT_GAIN_LIMIT_MAX);
     }


### PR DESCRIPTION
Description:
- If DE is switched off, dialogueEnhancementGainPreference shall be also set to 0, like dialogueEnhancementGain.

Testing:
- All DE test of HbbTv204 test. 
  You may need Set Setup > Manual > Interactive Test Steps to Yes in the Harness.