### PR TITLE
Implement rdk solution for dk-org.hbbtv_DASH-EVENT110+

### DIFF
--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -696,6 +696,9 @@ hbbtv.objects.DashProxy = (function() {
             p.player.on('manifestLoaded', p.onManifestLoaded);
             p.player.on('periodSwitchCompleted', p.onPeriodChanged);
             p.player.on('streamUpdated', p.onStreamUpdated);
+            p.player.on('representationSwitch', (e) => {
+                hbbtv.native.dispatchRepresentationNativeEvents?.(e.currentRepresentation);
+            });
 
             for (const scheme of PARENTAL_CONTROL_EVENT_SCHEMES) {
                 p.player.on(scheme, p.onParentalRatingChange);

--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -461,6 +461,14 @@ hbbtv.mediaManager = (function() {
         media.addTextTrack = function() {
             return textTracks.orb_addTextTrack.apply(textTracks, arguments);
         };
+
+        media.addTrackEvent = function() {
+            return textTracks.orb_addTrackEvent.apply(textTracks);
+        };
+        media.removeTrackEvent = function() {
+            return textTracks.orb_removeTrackEvent.apply(textTracks);
+        };
+     
     }
 
     // Mutation observer

--- a/src/mediaproxies/tracklists/texttracklist.js
+++ b/src/mediaproxies/tracklists/texttracklist.js
@@ -105,6 +105,17 @@ hbbtv.objects.TextTrackList = (function() {
         }
     };
 
+    // helper methods for addtrack, removetrack events
+    prototype.orb_addTrackEvent = function() {
+        const p = privates.get(this);
+        p.eventTarget.dispatchEvent(new TrackEvent('addtrack'));
+    };
+
+    prototype.orb_removeTrackEvent = function() {
+        const p = privates.get(this);
+        p.eventTarget.dispatchEvent(new TrackEvent('removetrack'));
+    };
+
     function initialise(mediaElement, proxy) {
         const TEXT_TRACK_LIST_KEY = 'TextTrackList';
         privates.set(this, {


### PR DESCRIPTION
Description
Addition of new rdk native events, used to track changes on different mpds regarding EventStream and changes to different Representations regarding InbandEventStream. The changes are rdk specific except some helper methods that will not affect the functionality.

Tests
org.hbbtv_DASH-EVENT0110
org.hbbtv_DASH-EVENT0120
org.hbbtv_DASH-EVENT0130
org.hbbtv_DASH-EVENT0140