### PR TITLE
Add implementation for Configuration.getCleanAudioEnabled api

### DIFF
--- a/rdk/ORB/library/src/core/requestHandlers/ConfigurationRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/ConfigurationRequestHandler.cpp
@@ -39,6 +39,7 @@
 #define CONFIGURATION_REQUEST_ACCESS_TO_DISTINCTIVE_IDENTIFIER \
     "requestAccessToDistinctiveIdentifier"
 #define CONFIGURATION_GET_PRIMARY_DISPLAY "getPrimaryDisplay"
+#define CONFIGURATION_GET_CLEAN_AUDIO_ENABLED "getCleanAudioEnabled"
 
 namespace orb {
 /**
@@ -193,6 +194,15 @@ bool ConfigurationRequestHandler::Handle(
             ORBEngine::GetSharedInstance().GetApplicationManager()->GetCurrentAppNames();
         ORBEngine::GetSharedInstance().GetORBPlatform()->
         Configuration_RequestAccessToDistinctiveIdentifier(origin, appNames);
+    }
+        // Configuration.getCleanAudioEnabled
+    else if (method == CONFIGURATION_GET_CLEAN_AUDIO_ENABLED)
+    {
+        json jsonPayload = token["payload"];
+        std::string origin = jsonPayload.value("origin", "");
+        bool enabled =
+            ORBEngine::GetSharedInstance().GetORBPlatform()->Configuration_GetCleanAudioEnabled();
+        response["result"] = enabled;
     }
 #ifdef BBC_API_ENABLE
     // Configuration.getPrimaryDisplay

--- a/rdk/ORB/library/src/platform/ORBPlatform.h
+++ b/rdk/ORB/library/src/platform/ORBPlatform.h
@@ -510,6 +510,14 @@ public:
      */
     virtual std::string Configuration_GetUserAgentString() = 0;
 
+
+    /**
+     * Get whether clean audio is enabled on this system.
+     *
+     * @return True if clean audio is enabled; or false otherwise.
+     */
+    virtual bool Configuration_GetCleanAudioEnabled() = 0;
+
 #ifdef BBC_API_ENABLE
     /**
      * Get a report of the device's primary display capabilities in accordance with the BBC TV

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.cpp
@@ -995,6 +995,17 @@ std::string ORBPlatformMockImpl::Configuration_GetUserAgentString()
     return userAgentString;
 }
 
+/**
+ * Get whether clean audio is enabled on this system.
+ *
+ * @return True if clean audio is enabled; or false otherwise.
+ */
+bool ORBPlatformMockImpl::Configuration_GetCleanAudioEnabled()
+{
+    ORB_LOG_NO_ARGS();
+    return false;
+}
+
 #ifdef BBC_API_ENABLE
 /**
  * Get a report of the device's primary display capabilities in accordance with the BBC TV

--- a/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
+++ b/rdk/ORB/platform-mock/src/ORBPlatformMockImpl.h
@@ -89,6 +89,7 @@ public:
     virtual bool Configuration_RequestAccessToDistinctiveIdentifier(std::string origin,
         std::map<std::string, std::string> appNames) override;
     virtual std::string Configuration_GetUserAgentString() override;
+    virtual bool Configuration_GetCleanAudioEnabled() override;
 #ifdef BBC_API_ENABLE
     virtual std::shared_ptr<DisplayInfo> Configuration_GetPrimaryDisplay() override;
 #endif


### PR DESCRIPTION
Description
Enable endpoint for Configuration.getCleanAudioEnabled API in RDK

Tests:
org.hbbtv_HTML50160
org.hbbtv_HTML50165