### PR TITLE
Fix OpenRedButtonProject/orb/pull/274 regression

### DIFF
--- a/src/objects/avcontrol.js
+++ b/src/objects/avcontrol.js
@@ -635,7 +635,7 @@ hbbtv.objects.AVControl = (function() {
                 for (let i = 0; i < audioTracks.length; ++i) {
                     const audioTrack = audioTracks[i];
                     if (!onlyActive || audioTrack.enabled) {
-                        let trackEncoding = audioTrack.encoding ? audioTrack.encoding.split('"')[1] : undefined
+                        let trackEncoding = audioTrack.encoding ? audioTrack.encoding.split('"')[1] : undefined;
                         if (isMPEG4HEAAC(trackEncoding)) {
                             trackEncoding = "HEAAC";
                         } else if (isEAC3(trackEncoding)) {
@@ -644,10 +644,11 @@ hbbtv.objects.AVControl = (function() {
                                       
                         let language = 'und';
                         if (audioTrack.language) {
-                            if (priv.ISO639_1_to_ISO639_2[audioTrack.language]) {
-                                language = priv.ISO639_1_to_ISO639_2[audioTrack.language];
-                            }
-                            else {
+                            let lang;
+                            if ((this.type !== 'application/dash+xml') &&
+                                (lang = priv.ISO639_1_to_ISO639_2[audioTrack.language])) {
+                                    language = lang;
+                            } else {
                                 language = audioTrack.language;
                             }
                         }


### PR DESCRIPTION
According to HbbTV Annex A.2.12.3 Modifications to clause 8.4.6, "Where
an AudioTrack corresponds to an MPEG DASH adaptation set or
Preselection, the value of the AudioTrack.language attribute shall be
the value of the lang attribute in the MPD". And that is an ISO 639-1
two-character code, the conversion is not necessary for DASH.