### PR TITLE
Add handling for pref language

### DIFF
--- a/src/mediaproxies/tracklists/audiotracklist.js
+++ b/src/mediaproxies/tracklists/audiotracklist.js
@@ -201,10 +201,12 @@ hbbtv.objects.AudioTrackList = (function() {
 
     function initialise(proxy) {
         const AUDIO_TRACK_LIST_KEY = 'AudioTrackList';
+        const prefLang = hbbtv.bridge.configuration.getPreferredAudioLanguage();
+
         privates.set(this, {
             length: 0,
             eventTarget: document.createDocumentFragment(),
-            defaultAudioLanguage: hbbtv.bridge.configuration.getPreferredAudioLanguage(),
+            defaultAudioLanguage: prefLang.includes(',') ? prefLang.split(',')[0] : prefLang,
             cleanAudioEnabled: hbbtv.bridge.configuration.getCleanAudioEnabled(),
             proxy,
         });


### PR DESCRIPTION
Description
Fix for cases when the prefered language returned by platform, is a comma separated list

Tests
org.hbbtv_HTML50160
org.hbbtv_HTML50165