### PR TITLE
Pass org.hbbtv_DASH-XLINK0013

### DIFF
--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -326,6 +326,9 @@ hbbtv.objects.DashProxy = (function() {
                 this.dispatchEvent(nativeEvt);
                 data.code = 5; // content not available
                 break;
+            case DOWNLOAD_ERROR_ID_XLINK_CODE:
+                // xlink:href couldn't be fetched. Xlink attributes are simply removed by dash.js
+                return;
             default:
                 data.code = 2; // Unidentified error
                 break;


### PR DESCRIPTION
Ignore errors when xlink:href couldn't be fetched.
Xlink attributes are simply removed by dash.js, and it will use the adaptation set defined locally in MPD.