### PR TITLE
Modify orb_addCue to ensure cue list is a charCode array

### DIFF
--- a/src/mediaproxies/tracklists/texttrackcuelist.js
+++ b/src/mediaproxies/tracklists/texttrackcuelist.js
@@ -44,6 +44,18 @@ hbbtv.objects.TextTrackCueList = (function() {
             }
         }
         const p = privates.get(this);
+        
+        // cue data needs to be an array of char codes
+        if (Array.isArray(cue.data)) {
+            cue.data = cue.data.map((e) => {
+                if (typeof e === 'number') {
+                    return e;
+                }
+                else {
+                    return e.charCodeAt();
+                }
+            });
+        }
         this[p.length] = cue;
         ++p.length;
     };


### PR DESCRIPTION
Description
The text cues need to be in charCode form for test org.hbbtv_DASH-131-EVENTS0120 to pass. Ensure that the text cue array holds those charCodes in orb_addCue

Tests
org.hbbtv_DASH-131-EVENTS0120