### PR TITLE
Pass org.hbbtv_HTML5-DASH003

### DIFF
--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -214,6 +214,7 @@ hbbtv.objects.DashProxy = (function() {
     prototype.load = function() {
         const p = privates.get(this);
         if (p) {
+            delete p.startDate;
             if (!this.src) {
                 // in this case, the source url is removed
                 // so we call the original load() in order to
@@ -568,13 +569,19 @@ hbbtv.objects.DashProxy = (function() {
         p.periods = e.data.Period_asArray;
         p.mrsUrl = e.data.mrsUrl;
         p.ciAncillaryData = e.data.ciAncillaryData;
-        
+        if (!p.startDate) {
+            p.startDate = Date.parse(e.data.availabilityStartTime);
+            if ((p.periods.length > 0) && (p.periods[0].start)) {
+                p.startDate += p.periods[0].start * 1000;
+            }
+        }
+
         const evt = new Event('__orb_startDateUpdated__');
         Object.assign(evt, {
-            startDate: Date.parse(e.data.availabilityStartTime),
+            startDate: p.startDate
         });
         this.dispatchEvent(evt);
-        
+
         hbbtv.native.dispatchManifestNativeEvents?.(e);
 
         console.log(

--- a/src/mediaproxies/mediamanager.js
+++ b/src/mediaproxies/mediamanager.js
@@ -73,13 +73,16 @@ hbbtv.mediaManager = (function() {
         // when calling play() immediately after setting the src attribute
         HTMLMediaElement.prototype.play = function() {
             const thiz = this;
+
             return new Promise((resolve, reject) => {
                 if (thiz.readyState < 2) {
                     const playFcn = function() {
-                        thiz.removeEventListener('loadeddata', playFcn);
+                        thiz.removeEventListener('loadeddata', playFcn, true);
+                        thiz.removeEventListener('progress', playFcn, true);
                         __play.call(thiz).then(resolve, reject);
                     };
                     thiz.addEventListener('loadeddata', playFcn, true);
+                    thiz.addEventListener('progress', playFcn, true);
                 } else {
                     __play.call(thiz).then(resolve, reject);
                 }
@@ -457,7 +460,7 @@ hbbtv.mediaManager = (function() {
         hbbtv.native.addMediaNativeListeners?.();
         media.addEventListener(hbbtv.native.getSeekablePollingEvent(), (e) => hbbtv.native.updateSeekable(e));
         media.addEventListener(hbbtv.native.getBufferedPollingEvent(), updateBuffered);
-        
+
         media.addEventListener('timeupdate', makeCallback('currentTime'));
         media.addTextTrack = function() {
             return textTracks.orb_addTextTrack.apply(textTracks, arguments);
@@ -469,7 +472,7 @@ hbbtv.mediaManager = (function() {
         media.removeTrackEvent = function() {
             return textTracks.orb_removeTrackEvent.apply(textTracks);
         };
-     
+
     }
 
     // Mutation observer


### PR DESCRIPTION
HBBTV 9.4.2
The origin of the media timeline used by HTML5 media elements (i.e. the &lt;audio&gt; and &lt;video&gt; elements) shall be the start time of the first Period that was defined in the MPD when the MPD was first loaded. The origin of the media timeline shall not change unless the HTML5 media element source is changed or the load() method is called. [...] For a dynamic MPD, getStartDate() shall return a Date oject representing the value of MPD@availabilityStartTime plus the PeriodStart time (see clause 5.3.2.1 of MPEG DASH ISO/IEC 23009-1 [29]) of the first regular Period when the MPD was first loaded.

Thus:
- startDate is only calculated once.
- startDate is forgotten on load() calls.

In addition to that, the loadeddata event is not triggered for this MPD (first period has a start of 3 seconds, dashjs bug?), so we also watch for progress events to call play() when play() was called immediately after setting the src attribute. progress events are fired with this MPD.