### PR TITLE
Pass org.hbbtv_DASH-SE0031

### DIFF
--- a/src/mediaproxies/dashproxy.js
+++ b/src/mediaproxies/dashproxy.js
@@ -661,6 +661,7 @@ hbbtv.objects.DashProxy = (function() {
                     dispatchEvent: false,
                 },
                 streaming: {
+                    fragmentRequestTimeout: 20000,
                     trackSwitchMode: {
                         audio: 'alwaysReplace',
                         video: 'neverReplace',


### PR DESCRIPTION
The test will eventually try to download a 1080p segment of ~2600000 bytes when the bandwidth is restricted to 1100000 bps. This would take 2600000 * 8 / 1100000 = 18 seconds, when Dashjs default timeout is 10 seconds (set in /src/core/Settings.js Line 865).
Recent versions of Dashjs use a default value of 20 seconds for fragmentRequestTimeout as well:
https://github.com/Dash-Industry-Forum/dash.js/blob/ca4c7aa0227d001bb31801faa61a2d57c4e14da4/src/core/Settings.js#L1162