### PR TITLE
Fix org.hbbtv_DASH-TIMELINE0140

### DIFF
--- a/src/objects/avcontrol.js
+++ b/src/objects/avcontrol.js
@@ -356,7 +356,11 @@ hbbtv.objects.AVControl = (function() {
                 position > 0 &&
                 priv.videoElement.duration > position / 1000.0
             ) {
-                priv.videoElement.currentTime = position / 1000.0;
+                if (priv.startDate) { /* dynamic DASH MPD */
+                    priv.videoElement.currentTime = (priv.startDate + position) / 1000.0;
+                } else {
+                    priv.videoElement.currentTime = position / 1000.0;
+                }
 
                 // needed in case we are in rewind mode
                 priv.rewindStartSystemTime = new Date().getTime();
@@ -1257,6 +1261,10 @@ hbbtv.objects.AVControl = (function() {
                     unloadSource.call(thiz);
                 }
             }
+        });
+
+        videoElement.addEventListener('__orb_startDateUpdated__', (e) => {
+            priv.startDate = e.startDate;
         });
 
         videoElement.addEventListener('__orb_onerror__', (e) => {


### PR DESCRIPTION
In dynamic DASH MPDs, the seek operation is relative to the startDate (MPD@availabilityStartTime plus the PeriodStart time of the first regular Period when the MPD was first loaded).
priv.startDate only gets a non null value when the MPD is dynamic.