### PR TITLE
Thread cancel and MetadataSearchTask remove

### DIFF
--- a/rdk/ORB/library/src/core/ORBEngine.h
+++ b/rdk/ORB/library/src/core/ORBEngine.h
@@ -26,6 +26,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 
 namespace orb
 {
@@ -232,16 +233,19 @@ public:
     // orb metadata search task pool handling
     void AddMetadataSearchTask(int queryId, std::shared_ptr<MetadataSearchTask> searchTask)
     {
+        std::lock_guard<std::mutex> lock{m_mutex};
         m_metadataSearchTasks[queryId] = searchTask;
     }
 
     void RemoveMetadataSearchTask(int queryId)
     {
+        std::lock_guard<std::mutex> lock{m_mutex};
         m_metadataSearchTasks.erase(queryId);
     }
 
     std::shared_ptr<MetadataSearchTask> GetMetadataSearchTask(int queryId)
     {
+        std::lock_guard<std::mutex> lock{m_mutex};
         return m_metadataSearchTasks[queryId];
     }
 
@@ -269,5 +273,6 @@ private:
     std::string m_currentAppUrl;
     bool m_started;
     std::string m_preferredUiLanguage;
+    mutable std::mutex m_mutex;
 }; // class ORBEngine
 } // namespace orb

--- a/rdk/ORB/library/src/core/requestHandlers/BroadcastRequestHandler.cpp
+++ b/rdk/ORB/library/src/core/requestHandlers/BroadcastRequestHandler.cpp
@@ -595,13 +595,15 @@ bool BroadcastRequestHandler::IsRequestAllowed(json token, ApplicationManager::M
  */
 void BroadcastRequestHandler::CancelSearch(int queryId)
 {
-    std::shared_ptr<MetadataSearchTask> searchTask =
-        ORBEngine::GetSharedInstance().GetMetadataSearchTask(queryId);
+    ORBEngine &engine = ORBEngine::GetSharedInstance();
+    std::shared_ptr<MetadataSearchTask> searchTask = engine.GetMetadataSearchTask(queryId);
     if (searchTask)
     {
         ORB_LOG("Aborting existing search task");
         searchTask->Stop();
-        ORBEngine::GetSharedInstance().RemoveMetadataSearchTask(queryId);
+        // REMARK: this is safe as the detached thread has its own shared_ptr ensuring that
+        //         the task is not destroyed while it is running.
+        engine.RemoveMetadataSearchTask(queryId);
     }
 }
 } // namespace orb

--- a/rdk/ORB/library/src/core/utilities/MetadataSearchTask.h
+++ b/rdk/ORB/library/src/core/utilities/MetadataSearchTask.h
@@ -22,6 +22,7 @@
 #include "Programme.h"
 #include "Query.h"
 #include <thread>
+#include <atomic>
 
 // Supported search status values
 #define SEARCH_STATUS_COMPLETED   0
@@ -35,7 +36,7 @@ namespace orb {
  * in its own dedicated thread. The search results shall be sent to the JavaScript
  * context asynchronously by means of the 'MetadataSearch' bridge event.
  */
-class MetadataSearchTask {
+class MetadataSearchTask : public std::enable_shared_from_this<MetadataSearchTask> {
 public:
 
     /**
@@ -133,5 +134,6 @@ private:
     int m_count;
     std::vector<std::string> m_channelConstraints;
     std::vector<std::string> m_searchResults;
+    std::atomic<bool> m_cancelled{false};
 }; // class MetadataSearchTask
 } // namespace orb


### PR DESCRIPTION
Description
Test org.hbbtv_0000F000 fails consistently and the reason of failure is related to the way we handle the MetadataSearchTask removal. Apply the changes that Sky proposed to fix the issue

Tests
org.hbbtv_0000F000