### PR TITLE
Fix org.hbbtv_E1210060 and org.hbbtv_E1210070

### DIFF
--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/WebResourceClient.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/WebResourceClient.java
@@ -142,11 +142,11 @@ abstract class WebResourceClient {
                 requestHeaders.put("Cookie", cookie);
             }
         }
-        
+
         if (mDoNotTrackEnabled) {
             requestHeaders.put("DNT", "1");
         }
-        
+
         Response httpResponse = mHttpClient.newCall(new Request.Builder()
                 .url(url)
                 .method(request.getMethod(), null)
@@ -268,8 +268,10 @@ abstract class WebResourceClient {
             String fromExtension = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
             if (fromExtension != null) {
                 type = fromExtension;
-            } else if ((extension.equals("html5")) || (extension.equals("cehtml"))) {
+            } else if (extension.equals("html5")) {
                 type = "text/html";
+            } else if (extension.equals("cehtml")) {
+                type = "application/xhtml+xml";
             }
         }
         return type;


### PR DESCRIPTION
.cehtml files coming from the carousel have to have application/xhtml+xml mime type, instead of text/html. Otherwise some self closed elements like <object /> would be hanlded as the beginning of the <object> tag, and mess how the page is interpreted