### PR TITLE
Fix org.hbbtv_SUB0120

### DIFF
--- a/src/mediaproxies/nativeproxy.js
+++ b/src/mediaproxies/nativeproxy.js
@@ -90,7 +90,7 @@ hbbtv.objects.NativeProxy = (function() {
             textTrackInfo.kind = trackElement.kind;
             textTrackInfo.id = trackElement.id;
             textTrackInfo.lang = trackElement.srclang;
-            textTrackInfo.labels = trackElement.label;
+            textTrackInfo.label = trackElement.label;
             textTrackInfo.isFragmented = false;
 
             let src = trackElement.getAttribute('src');

--- a/src/mediaproxies/tracklists/texttracklist.js
+++ b/src/mediaproxies/tracklists/texttracklist.js
@@ -74,6 +74,16 @@ hbbtv.objects.TextTrackList = (function() {
 
     prototype.orb_addTextTrack = function(kind, label, language) {
         const p = privates.get(this);
+
+        for (let i = 0; i < p.length; i++) {
+            const track = this[i];
+            if ((track.kind === kind) && (track.label === label) && (track.language === language)) {
+                if (track.mode === 'showing') {
+                    track.mode = track.mode;
+                }
+                return track;
+            }
+        }
         const track = hbbtv.objects.createTextTrack(
             p.mediaElement,
             p.proxy,
@@ -124,6 +134,11 @@ hbbtv.objects.TextTrackList = (function() {
             proxy,
             mediaElement,
         });
+
+        for (let i = 0; i < mediaElement.textTracks.length; i++) {
+            const track = mediaElement.textTracks[i];
+            this.orb_addTextTrack(track.kind, track.label, track.language);
+        }
         proxy.registerObserver(TEXT_TRACK_LIST_KEY, this);
 
         // We create a new Proxy object which we return in order to avoid ping-pong calls


### PR DESCRIPTION
The original video element gets the subtitle track mode set to 'showing' before the iframe player gets initialised. A call setting mode to 'showing' is needed to get the iframe player to handle the required change.