### PR TITLE
Fix org.hbbtv_DASH-TIMELINE0070 and org.hbbtv_DASH-TIMELINE0150

### DIFF
--- a/src/objects/avcontrol.js
+++ b/src/objects/avcontrol.js
@@ -1074,6 +1074,7 @@ hbbtv.objects.AVControl = (function() {
     }
 
     function initialise() {
+        let initialising = true;
         let startPlaying = false;
         let seeking = false;
         let priv = privates.get(this);
@@ -1203,25 +1204,27 @@ hbbtv.objects.AVControl = (function() {
             if (!seeking) {
                 videoElement.oncanplaythrough = () => {
                     videoElement.oncanplaythrough = undefined;
+                    initialising = false;
                     startPlaying = true;
                 };
             }
         });
 
         videoElement.addEventListener('play', () => {
+            initialising = false;
             startPlaying = true;
         });
 
         videoElement.addEventListener('seeking', () => {
-            if (!startPlaying && !seeking) {
+            if (!initialising && !startPlaying && !seeking) {
                 seeking = true;
             }
         });
 
         videoElement.addEventListener('seeked', () => {
-            seeking = false;
-            if (priv.targetSpeed > 0) {
+            if (seeking && (priv.targetSpeed > 0)) {
                 transitionToState.call(thiz, PLAY_STATE_PLAYING);
+                seeking = false;
             }
         });
 


### PR DESCRIPTION
During dash.js initialisation a seek operation is performed before starting to play the stream. avcontrol.js will mistakenly transition to PLAYING state. avcontrol.js just needs to ignore this operation while it is in the initialisation phase (before play is called).