### PR TITLE
Fix HTM-768

### DIFF
--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/Bridge.java
@@ -619,6 +619,20 @@ class Bridge extends AbstractBridge {
     }
 
     /**
+     * Get the other keys for this application.
+     *
+     * The calling application is identified by the token associated with the request.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return The other keys for this application.
+     */
+    @Override
+    protected int[] Manager_getOtherKeyValues(BridgeToken token) {
+        return mApplicationManager.getOtherKeyValues(token.getAppId());
+    }
+
+    /**
      * Get the maximum keyset available to applications.
      *
      * @param token The token associated with this request.
@@ -631,18 +645,33 @@ class Bridge extends AbstractBridge {
     }
 
     /**
+     * Get the maximum other keys available to applications.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return The maximum other keys available to applications.
+     */
+    @Override
+    protected int Manager_getKeyMaximumOtherKeys(BridgeToken token) {
+        return mApplicationManager.getKeyMaximumOtherKeys();
+    }
+
+    /**
      * Set the keyset for this application.
      *
      * The calling application is identified by the token associated with the request.
      *
      * @param token The token associated with this request.
      * @param value The keyset to set for this application.
+     * @param otherKeys The key events which are available to the browser & are not 
+     *    included in one of the keySet constants 
      *
      * @return The keyset for this application.
      */
     @Override
-    protected int Manager_setKeyValue(BridgeToken token, int value) {
-        return mApplicationManager.setKeyValue(token.getAppId(), value);
+    protected int Manager_setKeyValue(BridgeToken token, int value, List<String> otherKeys)
+    {
+        return mApplicationManager.setKeyValue(token.getAppId(), value, otherKeys);
     }
 
     /**

--- a/android/orblibrary/src/main/java/org/orbtv/orblibrary/BrowserView.java
+++ b/android/orblibrary/src/main/java/org/orbtv/orblibrary/BrowserView.java
@@ -299,7 +299,8 @@ class BrowserView extends WebView {
                 keyCode != KeyEvent.KEYCODE_MEDIA_PAUSE &&
                 keyCode != KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE &&
                 keyCode != KeyEvent.KEYCODE_MEDIA_REWIND &&
-                keyCode != KeyEvent.KEYCODE_MEDIA_FAST_FORWARD;
+                keyCode != KeyEvent.KEYCODE_MEDIA_FAST_FORWARD &&
+                keyCode != KeyEvent.KEYCODE_MEDIA_RECORD;
     }
 
     private void dispatchJavaScriptBridgeEvent(String type, JSONObject properties) {

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/AbstractBridge.java
@@ -867,6 +867,17 @@ public abstract class AbstractBridge {
     protected abstract int Manager_getKeyValues(BridgeToken token);
 
     /**
+     * Get the other keys for this application.
+     *
+     * The calling application is identified by the token associated with the request.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return The other keys for this application.
+     */
+    protected abstract int[] Manager_getOtherKeyValues(BridgeToken token);
+
+    /**
      * Get the maximum keyset available to applications.
      *
      * @param token The token associated with this request.
@@ -876,16 +887,27 @@ public abstract class AbstractBridge {
     protected abstract int Manager_getKeyMaximumValue(BridgeToken token);
 
     /**
+     * Get the maximum other keys available to applications.
+     *
+     * @param token The token associated with this request.
+     *
+     * @return The maximum other keys available to applications.
+     */
+    protected abstract int Manager_getKeyMaximumOtherKeys(BridgeToken token);
+
+    /**
      * Set the keyset for this application.
      *
      * The calling application is identified by the token associated with the request.
      *
      * @param token The token associated with this request.
      * @param value The keyset to set for this application.
+     * @param otherKeys The key events which are available to the browser & are not 
+     *    included in one of the keySet constants 
      *
      * @return The keyset for this application.
      */
-    protected abstract int Manager_setKeyValue(BridgeToken token, int value);
+    protected abstract int Manager_setKeyValue(BridgeToken token, int value, List<String> otherKeys);
 
     /**
      * Get the URL of an icon that represents the given key.
@@ -1748,6 +1770,18 @@ public abstract class AbstractBridge {
                 break;
             }
 
+            case "Manager.getOtherKeyValues": {
+                int[] resultOtherKeys = Manager_getOtherKeyValues(
+                        token
+                );
+                JSONArray result = new JSONArray();
+                for (int i : resultOtherKeys) {
+                    result.put(i);
+                }
+                response.put("result", result);
+                break;
+            }
+
             case "Manager.getKeyMaximumValue": {
                 int result = Manager_getKeyMaximumValue(
                         token
@@ -1756,10 +1790,27 @@ public abstract class AbstractBridge {
                 break;
             }
 
+            case "Manager.getKeyMaximumOtherKeys": {
+                int result = Manager_getKeyMaximumOtherKeys(
+                        token
+                );
+                response.put("result", result);
+                break;
+            }
+
             case "Manager.setKeyValue": {
+                List<String> otherKeysList = new ArrayList<>();
+                if (!params.isNull("otherKeys")) {
+                    JSONArray otherKeys = params.getJSONArray("otherKeys");
+                    for (int i = 0; i < otherKeys.length(); i++) {
+                        otherKeysList.add(otherKeys.getString(i));
+                    }
+                }
+
                 int result = Manager_setKeyValue(
                         token,
-                        params.getInt("value")
+                        params.getInt("value"),
+                        otherKeysList
                 );
                 response.put("result", result);
                 break;

--- a/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeTypes.java
+++ b/android/orbpolyfill/src/main/java/org/orbtv/orbpolyfill/BridgeTypes.java
@@ -93,6 +93,7 @@ public class BridgeTypes {
     public static final int VK_PLAY_PAUSE = 402;
     public static final int VK_FAST_FWD = 417;
     public static final int VK_REWIND = 412;
+    public static final int VK_RECORD = 416;
     public static final int VK_TELETEXT = 459;
 
     // Codes used to indicate search status. See OIPF spec vol 5 DAE, section 7.12.1.1

--- a/components/application_manager/app.cpp
+++ b/components/application_manager/app.cpp
@@ -38,6 +38,7 @@ App App::CreateAppFromUrl(const std::string &url)
     app.appId = 0;
 
     app.keySetMask = 0;
+    app.otherKeys = std::vector<uint16_t>();
 
     app.isTrusted = false;
     app.isBroadcast = false;
@@ -71,6 +72,7 @@ App App::CreateAppFromAitDesc(const Ait::S_AIT_APP_DESC *desc,
     app.graphicsConstraints = desc->graphicsConstraints;
 
     app.keySetMask = 0;
+    app.otherKeys = std::vector<uint16_t>();
 
     app.isTrusted = isTrusted;
     app.isBroadcast = isBroadcast;

--- a/components/application_manager/app.h
+++ b/components/application_manager/app.h
@@ -58,6 +58,7 @@ public:
     uint16_t appId;
 
     uint16_t keySetMask;
+    std::vector<uint16_t> otherKeys;
 
     bool isTrusted;
     bool isBroadcast;

--- a/components/application_manager/application_manager.h
+++ b/components/application_manager/application_manager.h
@@ -175,9 +175,10 @@ public:
      *
      * @param appId The application.
      * @param keySetMask The key set mask.
+     * @param otherKeys optional other keys
      * @return The key set mask for the application.
      */
-    uint16_t SetKeySetMask(uint16_t appId, uint16_t keySetMask);
+    uint16_t SetKeySetMask(uint16_t appId, uint16_t keySetMask, std::vector<uint16_t> otherKeys);
 
     /**
      * Get the key set mask for an application.
@@ -186,6 +187,14 @@ public:
      * @return The key set mask for the application.
      */
     uint16_t GetKeySetMask(uint16_t appId);
+
+    /**
+     * Get the other keys for an application.
+     *
+     * @param appId The application.
+     * @return The other keys for the application.
+     */
+    std::vector<uint16_t> GetOtherKeyValues(uint16_t appId);
 
     /**
      * Check the key code is accepted by the current key mask. Activate the app as a result if the

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -750,6 +750,20 @@ hbbtv.bridge.manager = (function() {
     };
 
     /**
+     * Get the other for this application.
+     *
+     * The calling application is identified by the token associated with the request.
+     *
+     * @return {number} The other keys for this application.
+     *
+     * @method
+     * @memberof bridge.manager#
+     */
+    exported.getOtherKeyValues = function() {
+        return hbbtv.native.request('Manager.getOtherKeyValues').result;
+    };
+
+    /**
      * Get the maximum keyset available to applications.
      *
      * @return {number} }he maximum keyset available to applications.
@@ -759,6 +773,18 @@ hbbtv.bridge.manager = (function() {
      */
     exported.getKeyMaximumValue = function() {
         return hbbtv.native.request('Manager.getKeyMaximumValue').result;
+    };
+
+    /**
+     * Get the maximum other keys available to applications.
+     *
+     * @return {number} The maximum other keys available to applications.
+     *
+     * @method
+     * @memberof bridge.manager#
+     */
+    exported.getKeyMaximumValue = function() {
+        return hbbtv.native.request('Manager.getKeyMaximumOtherKeys').result;
     };
 
     /**

--- a/src/objects/keyset.js
+++ b/src/objects/keyset.js
@@ -44,7 +44,10 @@ hbbtv.objects.KeySet = (function() {
 
     Object.defineProperty(prototype, 'otherKeys', {
         get() {
-            return [];
+            if (privates.get(this).disabled) {
+                return [];
+            }
+            return hbbtv.bridge.manager.getOtherKeyValues();
         },
     });
 
@@ -56,7 +59,7 @@ hbbtv.objects.KeySet = (function() {
 
     Object.defineProperty(prototype, 'maximumOtherKeys', {
         get() {
-            return 0;
+            return hbbtv.bridge.manager.getKeyMaximumOtherKeys();
         },
     });
 

--- a/src/polyfill/keyevent.js
+++ b/src/polyfill/keyevent.js
@@ -46,6 +46,7 @@
         VK_PLAY_PAUSE: 402,
         VK_FAST_FWD: 417,
         VK_REWIND: 412,
+        VK_RECORD: 416,
     };
     for (const key in keys) {
         if (!window.KeyEvent.hasOwnProperty(key)) {


### PR DESCRIPTION
- add support for otherKeys (oipf vol5, 7.2.5.2) org.hbbtv_DVBI_KEY0100 and org.hbbtv_DVBI_KEY0040
- add VK_RECORD key
- add an excetion to application manager so that the key events VK_STOP, VK_PLAY, VK_PAUSE, VK_PLAY_PAUSE, VK_FAST_FWD, VK_REWIND and VK_RECORD shall always be available to linked applications that are controlling media presentation without requiring the application to be activated first

Goes with: https://github.com/OpenRedButtonProject/orb-reference-android/pull/32