### PR TITLE
FREE-85 fix build errors

### DIFF
--- a/android/mockdialservice/.gitignore
+++ b/android/mockdialservice/.gitignore
@@ -1,1 +1,5 @@
 /build
+.gradle
+.idea
+local.properties
+

--- a/android/orblibrary/CMakeLists.txt
+++ b/android/orblibrary/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(
    ../../components/application_manager/ait.cpp
    ../../components/application_manager/xml_parser.cpp
    ../../components/application_manager/hbbtv_app.cpp
+   ../../components/application_manager/opapp.cpp
 )
 target_link_libraries(
    org.orbtv.orblibrary.applicationmanager

--- a/android/orblibrary/src/main/cpp/application_manager_native.cpp
+++ b/android/orblibrary/src/main/cpp/application_manager_native.cpp
@@ -168,23 +168,40 @@ public:
         return region;
     }
 
-    void DispatchApplicationSchemeUpdatedEvent(const int appId, const std::string &scheme) {
+    void DispatchApplicationSchemeUpdatedEvent(const int appId, const std::string &scheme) override
+    {
         JNIEnv *env = JniUtils::GetEnv();
         jstring j_appType = env->NewStringUTF(scheme.c_str());
         env->CallVoidMethod(mJavaCbObject, gCb[CB_ON_APPLICATION_TYPE_UPDATED], j_appType);
         env->DeleteLocalRef(j_appType);
     }
 
-    virtual bool isInstanceInCurrentService(const Utils::S_DVB_TRIPLET &triplet) {
+    bool isInstanceInCurrentService(const Utils::S_DVB_TRIPLET &triplet) override
+    {
         JNIEnv *env = JniUtils::GetEnv();
         return env->CallBooleanMethod(mJavaCbObject, gCb[CB_IS_INSTANCES_OF_CURRENT_SERVICE], triplet.originalNetworkId, triplet.transportStreamId, triplet.serviceId);
     }
 
 
-    void DispatchOperatorApplicationStateChange(const int appId, const std::string &oldState, const std::string &newState) { /* TODO */ }
-    void DispatchOperatorApplicationStateChangeCompleted(const int appId, const std::string &oldState, const std::string &newState) { /* TODO */ }
-    void DispatchOperatorApplicationContextChange(const int appId, const std::string &startupLocation, const std::string &launchLocation = "") { /* TODO */ }
-    void DispatchOpAppUpdate(const int appId, const std::string &updateEvent) { /* TODO */ }
+    void DispatchOperatorApplicationStateChange(const int appId, const std::string &oldState, const std::string &newState) override
+    {
+        /* TODO */
+    }
+
+    void DispatchOperatorApplicationStateChangeCompleted(const int appId, const std::string &oldState, const std::string &newState) override
+    {
+        /* TODO */
+    }
+
+    void DispatchOperatorApplicationContextChange(const int appId, const std::string &startupLocation, const std::string &launchLocation = "") override
+    {
+        /* TODO */
+    }
+
+    void DispatchOpAppUpdate(const int appId, const std::string &updateEvent) override
+    {
+        /* TODO */
+    }
 
 private:
     jobject mJavaCbObject;

--- a/components/application_manager/opapp.cpp
+++ b/components/application_manager/opapp.cpp
@@ -12,7 +12,8 @@ static std::string opAppStateToString(const HbbTVApp::E_APP_STATE &state);
  * @throws std::runtime_error
  */
 OpApp::OpApp(const std::string &url, ApplicationSessionCallback *sessionCallback)
-    : HbbTVApp(url, sessionCallback)
+    : HbbTVApp(url, sessionCallback),
+    m_countdown([&] () { SetState(BACKGROUND_STATE); })
 {
     m_state = BACKGROUND_STATE; // ETSI TS 103 606 V1.2.1 (2024-03) page 36
 }

--- a/components/application_manager/opapp.cpp
+++ b/components/application_manager/opapp.cpp
@@ -8,7 +8,7 @@ static std::string opAppStateToString(const HbbTVApp::E_APP_STATE &state);
 
 /**
  * Create opapp from url.
- * 
+ *
  * @throws std::runtime_error
  */
 OpApp::OpApp(const std::string &url, ApplicationSessionCallback *sessionCallback)
@@ -19,7 +19,7 @@ OpApp::OpApp(const std::string &url, ApplicationSessionCallback *sessionCallback
 
 /**
  * Create opapp from Ait description.
- * 
+ *
  * @throws std::runtime_error
  */
 OpApp::OpApp(const Ait::S_AIT_APP_DESC &desc, bool isNetworkAvailable, ApplicationSessionCallback *sessionCallback)
@@ -31,18 +31,20 @@ OpApp::OpApp(const Ait::S_AIT_APP_DESC &desc, bool isNetworkAvailable, Applicati
         true,
         false,
         sessionCallback
-    )
+    ),
+    m_countdown([&] () { SetState(BACKGROUND_STATE); })
 {
     m_state = BACKGROUND_STATE; // ETSI TS 103 606 V1.2.1 (2024-03) page 36
 }
 
 /**
  * Create opapp from url and inherit another opapp's state (ETSI TS 103 606 V1.2.1 (2024-03) 6.3.3.1).
- * 
+ *
  * @throws std::runtime_error
  */
 OpApp::OpApp(const OpApp &other, const std::string &url)
-    : HbbTVApp(url, other.m_sessionCallback)
+    : HbbTVApp(url, other.m_sessionCallback),
+    m_countdown([&] () { SetState(BACKGROUND_STATE); })
 {
     m_state = other.GetState();
     if (!other.m_countdown.isStopped())
@@ -53,7 +55,7 @@ OpApp::OpApp(const OpApp &other, const std::string &url)
 
 /**
  * Set the application state.
- * 
+ *
  * @param state The desired state to transition to.
  * @returns true if transitioned successfully to the desired state, false otherwise.
  */
@@ -67,7 +69,7 @@ bool OpApp::SetState(const E_APP_STATE &state)
             std::string next = opAppStateToString(state);
             m_state = state;
             m_sessionCallback->DispatchOperatorApplicationStateChange(GetId(), previous, next);
-            
+
             if (state == BACKGROUND_STATE)
             {
                 m_sessionCallback->HideApplication(GetId());
@@ -77,7 +79,7 @@ bool OpApp::SetState(const E_APP_STATE &state)
                 m_sessionCallback->ShowApplication(GetId());
             }
         }
-        
+
         if (state == TRANSIENT_STATE || state == OVERLAID_TRANSIENT_STATE)
         {
             m_countdown.start(std::chrono::milliseconds(COUNT_DOWN_TIMEOUT));
@@ -115,9 +117,9 @@ bool OpApp::CanTransitionToState(const E_APP_STATE &state)
                 }
                 break;
 
-            case TRANSIENT_STATE: // ETSI TS 103 606 V1.2.1 (2024-03) 6.3.3.4 Page 41 
-            case OVERLAID_TRANSIENT_STATE: // ETSI TS 103 606 V1.2.1 (2024-03) 6.3.3.6 Page 42 
-            case OVERLAID_FOREGROUND_STATE: // ETSI TS 103 606 V1.2.1 (2024-03) 6.3.3.5 Page 41 
+            case TRANSIENT_STATE: // ETSI TS 103 606 V1.2.1 (2024-03) 6.3.3.4 Page 41
+            case OVERLAID_TRANSIENT_STATE: // ETSI TS 103 606 V1.2.1 (2024-03) 6.3.3.6 Page 42
+            case OVERLAID_FOREGROUND_STATE: // ETSI TS 103 606 V1.2.1 (2024-03) 6.3.3.5 Page 41
                 // Allowed transitions from these states
                 if (state == FOREGROUND_STATE || state == BACKGROUND_STATE) {
                     return true;

--- a/components/application_manager/opapp.h
+++ b/components/application_manager/opapp.h
@@ -28,46 +28,46 @@ class OpApp : public HbbTVApp
 public:
     /**
      * Create opapp from url.
-     * 
+     *
      * @throws std::runtime_error
      */
     OpApp(const std::string &url, ApplicationSessionCallback *sessionCallback);
 
     /**
      * Create opapp from Ait description.
-     * 
+     *
      * @throws std::runtime_error
      */
     OpApp(const Ait::S_AIT_APP_DESC &desc, bool isNetworkAvailable, ApplicationSessionCallback *sessionCallback);
 
     /**
      * Create opapp from url and inherit another opapp's state (ETSI TS 103 606 V1.2.1 (2024-03) 6.3.3.1).
-     * 
+     *
      * @throws std::runtime_error
      */
     OpApp(const OpApp &other, const std::string &url);
-    
+
     virtual ~OpApp() = default;
 
     OpApp(const HbbTVApp&) = delete;
     OpApp &operator=(const OpApp&) = delete;
-    
+
     /**
      * Set the application state.
-     * 
+     *
      * @param state The desired state to transition to.
      * @returns true if transitioned successfully to the desired state, false otherwise.
      */
     bool SetState(const E_APP_STATE &state) override;
-    
+
     E_APP_TYPE GetType() const override { return HbbTVApp::E_APP_TYPE::OPAPP_TYPE; }
-    
+
     bool TransitionToBroadcastRelated() override;
 
 private:
     bool CanTransitionToState(const E_APP_STATE &state);
 
-    Utils::Timeout m_countdown = Utils::Timeout([&]() -> void { SetState(BACKGROUND_STATE); });
+    Utils::Timeout m_countdown;
 };
 
 #endif // OPAPP_H


### PR DESCRIPTION
This fixes a few build errors when trying to build mock203app. But it doesn't fix all of them!!

1) opapp.cpp needed to be added to CMakeLists.txt for orblibrary
2) Utils::Timeout initialisation used deleted constructor. Now initialisation in OpApp constructor list.

Also adds .gitignore for mockdialservice.