### PR TITLE
FREE-241: Validate BroadcastSupervisor can receive playStateChange

### DIFF
--- a/tests/integration/opapp/app.js
+++ b/tests/integration/opapp/app.js
@@ -128,6 +128,13 @@ class VideoBroadcast {
         console.log(`Selecting next channel through VBO...`);
         logEvent(`Selecting next channel through VBO...`);
         this.selectNextChannelWrapper(this.videoBroadcast);
+        setTimeout(() => {
+            // Verify that the BroadcastSupervisor PlayStateChange Event was triggered after selecting a channel
+            if (!this.BSPlayStateEventVerified) {
+                logEvent(`BroadcastSupervisor PlayStateChange Event Test: [FAIL]`, 'error');
+                console.log(`BroadcastSupervisor PlayStateChange Event Test: [FAIL]`);
+            }
+        }, 2000);
     }
 
     selectNextChannelBS() {


### PR DESCRIPTION
Jira Ticket link: https://oceanbluesoftware.atlassian.net/browse/FREE-241
1. FREE-241, Update logs to show test result of BroadcastSupervisor can receive playStateChange in RefTVApp.
2. Create a new object BroadcastSupervisor to simplify the code. 
3. Only Event playStateChange is supported from Video Window now.