### PR TITLE
FREE-283 Fix moderator unit tests

### DIFF
--- a/orblibrary/BUILD.gn
+++ b/orblibrary/BUILD.gn
@@ -20,6 +20,8 @@ static_library("orb") {
     "moderator/JsonRpcCallback.cpp",
     "moderator/VideoWindow.cpp",
     "moderator/WebSocketServerFactory.cpp",
+    "moderator/JsonImpl.cpp",
+    "moderator/FactoryImpl.cpp",
   ]
 
   deps = [
@@ -152,12 +154,28 @@ config("external_network_services_config") {
 
 source_set("test_orb_moderator_sources")
 {
-  sources = [ "test/moderator_unittest.cpp"]
+sources = [
+    "test/moderator_unittest.cpp",
+    "moderator/Moderator.cpp",
+    "moderator/Network.cpp",
+    "moderator/MediaSynchroniser.cpp",
+    "moderator/utilities/StringUtil.cpp",
+  ]
 
   deps = [
     "//testing/gtest",
-    ":orb"
+    "//testing/gmock",
+    "//third_party/orb/logging:orb_logging_deps",
+    "//base", # For logging dependency
   ]
+
+  include_dirs = [
+    "include",
+    "moderator",
+    "moderator/utilities",
+  ]
+
+  defines = ["IS_CHROMIUM","ORB_HBBTV_VERSION=204"]
 
   testonly = true
 }
@@ -187,6 +205,7 @@ source_set("test_orb_video_window_sources")
 
   deps = [
     "//testing/gtest",
+    "//testing/gmock",
     "//third_party/jsoncpp",
     "//base", # Seems to be some dependency on this for logging
     "//third_party/orb/logging:orb_logging_deps",
@@ -271,7 +290,7 @@ source_set("test_orb_application_manager_sources")
 executable("test_orb_all") {
   deps = [
     "//testing/gtest:gtest_main",
-    #":test_orb_moderator_sources", # TODO Fix in FREE-283
+    ":test_orb_moderator_sources",
     ":test_opapp_package_manager_sources",
     ":test_orb_video_window_sources",
     ":test_orb_util_sources",

--- a/orblibrary/include/FactoryImpl.h
+++ b/orblibrary/include/FactoryImpl.h
@@ -1,0 +1,76 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Factory Implementation
+ *
+ * Note: This file implements the IFactory interface for creating ORB components.
+ */
+
+#ifndef FACTORY_IMPL_H
+#define FACTORY_IMPL_H
+
+#include "IFactory.h"
+
+namespace orb
+{
+
+/**
+ * Factory Implementation
+ *
+ * This class implements the IFactory interface to create ORB components
+ */
+class FactoryImpl : public IFactory
+{
+public:
+    /**
+     * Constructor
+     */
+    FactoryImpl() = default;
+
+    /**
+     * Destructor
+     */
+    virtual ~FactoryImpl() = default;
+
+    /**
+     * Create an instance of IJson
+     *
+     * @param jsonString The JSON string to create the instance from
+     * @return A unique pointer to the created instance
+     */
+    std::unique_ptr<IJson> createJson(const std::string& jsonString = {}) override;
+
+    /**
+     * Create an instance of Drm
+     *
+     * @param jsonString The JSON string to create the instance from
+     * @return A unique pointer to the created instance
+     */
+    std::unique_ptr<ComponentBase> createDrm() override;
+
+    /**
+     * Create an instance of AppMgrInterface
+     *
+     * @param browser The browser instance
+     * @param apptype The application type
+     * @return A unique pointer to the created instance
+     */
+    std::unique_ptr<IAppMgrInterface> createAppMgrInterface(IOrbBrowser* browser, ApplicationType apptype) override;
+
+};
+
+} // namespace orb
+
+#endif // FACTORY_IMPL_H

--- a/orblibrary/include/IFactory.h
+++ b/orblibrary/include/IFactory.h
@@ -1,0 +1,76 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Generic Factory Interface
+ *
+ * Note: This file defines a generic factory interface for creating objects.
+ */
+
+#ifndef IFACTORY_H
+#define IFACTORY_H
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include "IJson.h"
+#include "OrbConstants.h"
+
+namespace orb
+{
+
+/**
+ * Generic Factory Interface
+ *
+ */
+
+class ComponentBase;
+class IAppMgrInterface;
+class IOrbBrowser;
+
+class IFactory
+{
+public:
+    /**
+     * Virtual destructor
+     */
+    virtual ~IFactory() = default;
+
+    /**
+     * Create an instance of IJson
+     *
+     * @param jsonString The JSON string to create the instance from
+     * @return A unique pointer to the created instance
+     */
+    virtual std::unique_ptr<IJson> createJson(const std::string& jsonString = {}) = 0;
+
+    /**
+     * Create an instance of Drm
+     *
+     * @return A unique pointer to the created instance
+     */
+    virtual std::unique_ptr<ComponentBase> createDrm() = 0;
+
+    /**
+     * Create an instance of AppMgrInterface
+     *
+     * @return A unique pointer to the created instance
+     */
+    virtual std::unique_ptr<IAppMgrInterface> createAppMgrInterface(IOrbBrowser* browser, ApplicationType apptype) = 0;
+};
+
+} // namespace orb
+
+#endif // IFACTORY_H

--- a/orblibrary/include/IJson.h
+++ b/orblibrary/include/IJson.h
@@ -1,0 +1,172 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef IJSON_H
+#define IJSON_H
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+#include <cstdint>
+
+namespace orb
+{
+
+
+enum JsonType
+{
+    JSON_TYPE_STRING,
+    JSON_TYPE_INTEGER,
+    JSON_TYPE_BOOLEAN,
+    JSON_TYPE_ARRAY,
+    JSON_TYPE_OBJECT
+};
+
+/**
+ * Interface for a Json class.
+ */
+class IJson
+{
+
+public:
+
+    virtual ~IJson() = default;
+
+    /**
+     * Checks if the Json is initialized.
+     *
+     * @return 'true' if the Json object was successfully initialized, 'false' otherwise.
+     */
+    virtual bool isInitialized() = 0;
+
+    /**
+     * Parses a JSON string into an Json object.
+     *
+     * @param jsonString The JSON string to parse.
+     * @return 'true' if the JSON string was successfully parsed, 'false' otherwise.
+     */
+    virtual bool parse(std::string jsonString) = 0;
+
+    /**
+     * Check if a Json object has a specified parameter with a certain JsonType.
+     *
+     * @param param The name of the parameter to search for within the Json object.
+     * @param type The expected data type of the parameter.
+     * @return 'true' if the parameter 'param' exists within the Json object
+     *          and has the specified JsonType, 'false' otherwise.
+     */
+    virtual bool hasParam(const std::string &param, const JsonType& type = JsonType::JSON_TYPE_OBJECT) = 0;
+
+    /**
+     * Converts current Json object to a string.
+     *
+     * @return A string representation of the Json object.
+     */
+    virtual std::string toString() = 0;
+
+    /**
+     * Gets an integer value from a Json object by key.
+     *
+     * @param key The key of the integer value in the Json object.
+     * @return The integer value if the key exists and the value is an integer,
+     *         0 otherwise.
+     */
+    virtual int getInteger(const std::string& key) = 0;
+
+    /**
+     * Gets a boolean value from a Json object by key.
+     *
+     * @param key The key of the boolean value in the Json object.
+     * @return The boolean value if the key exists and the value is a boolean,
+     *         false otherwise.
+     */
+    virtual bool getBool(const std::string& key) = 0;
+
+    /**
+     * Gets a string value from a Json object by key.
+     *
+     * @param key The key of the string value in the Json object.
+     * @return The string value if the key exists and the value is a string,
+     *         empty string otherwise.
+     */
+    virtual std::string getString(const std::string& key) = 0;
+
+    /**
+     * Gets an object value from a Json object by key.
+     *
+     * @param key The key of the object value in the Json object.
+     * @return The object value if the key exists and the value is an object,
+     *         nullptr otherwise.
+     */
+    virtual std::unique_ptr<IJson> getObject(const std::string& key) = 0;
+
+    /**
+     * Sets an integer value in a Json object by key.
+     *
+     * @param key The key of the integer value in the Json object.
+     * @param value The integer value to set.
+     * @param subKey The sub-key of the integer value in the Json object.
+     */
+    virtual void setInteger(const std::string& key, const int value, const std::string& subKey = {}) = 0;
+
+    /**
+     * Sets a boolean value in a Json object by key.
+     *
+     * @param key The key of the boolean value in the Json object.
+     * @param value The boolean value to set.
+     * @param subKey The sub-key of the boolean value in the Json object.
+     */
+    virtual void setBool(const std::string& key, const bool value, const std::string& subKey = {}) = 0;
+
+    /**
+     * Sets a string value in a Json object by key.
+     *
+     * @param key The key of the string value in the Json object.
+     * @param value The string value to set.
+     * @param subKey The sub-key of the string value in the Json object.
+     */
+     virtual void setString(const std::string& key, const std::string& value, const std::string& subKey = {}) = 0;
+
+    /**
+     * Sets an array with uint16_t values in a Json object by key.
+     *
+     * @param key The key of the array in the Json object.
+     * @param array The array of uint16_t to set.
+     * @param subKey The sub-key of the array value in the Json object.
+     */
+    virtual void setArray(const std::string& key, const std::vector<uint16_t>& array) = 0;
+
+    /**
+     * Sets an integer array in a Json object by key.
+     *
+     * @param key The key of the array in the Json object.
+     * @param array The array of integers to set.
+     * @param subKey The sub-key of the array value in the Json object.
+     */
+    virtual void setArray(const std::string& key, const std::vector<int>& array) = 0;
+
+    /**
+     * Gets an array of integers from a Json object by key.
+     *
+     * @param key The key of the integer array in the Json object.
+     * @return The integer array if the key exists and the value is an array of integers,
+     *         empty vector otherwise.
+     */
+    virtual std::vector<uint16_t> getUint16Array(const std::string& key) = 0;
+};
+
+} // namespace orb
+
+#endif // IJSON_H

--- a/orblibrary/include/JsonImpl.h
+++ b/orblibrary/include/JsonImpl.h
@@ -1,0 +1,65 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef JSONIMPL_H
+#define JSONIMPL_H
+
+#include "IJson.h"
+#include <json/json.h>
+
+namespace orb
+{
+
+/**
+ * Json implementation class.
+ * The methods implemented here are based on the JsonUtil class.
+ */
+class JsonImpl : public IJson
+{
+public:
+    JsonImpl();
+    JsonImpl(std::string jsonString);
+    JsonImpl(Json::Value json);
+    JsonImpl(std::vector<uint16_t> array);
+    JsonImpl(std::vector<int> array);
+    virtual ~JsonImpl() {}
+    bool isInitialized() override;
+    bool parse(std::string jsonString) override;
+    bool hasParam(const std::string &param, const JsonType& type = JsonType::JSON_TYPE_OBJECT) override;
+    std::string toString() override;
+    int getInteger(const std::string& key) override;
+    bool getBool(const std::string& key) override;
+    std::string getString(const std::string& key) override;
+    std::unique_ptr<IJson> getObject(const std::string& key) override;
+    void setInteger(const std::string& key, const int value, const std::string& subKey) override;
+    void setBool(const std::string& key, const bool value, const std::string& subKey) override;
+    void setString(const std::string& key, const std::string& value, const std::string& subKey) override;
+    void setArray(const std::string& key, const std::vector<uint16_t>& array) override;
+    void setArray(const std::string& key, const std::vector<int>& array) override;
+    std::vector<uint16_t> getUint16Array(const std::string& key) override;
+
+private:
+    Json::ValueType convertToJsonValueType(const JsonType& type);
+    void setValue(const std::string& key, Json::Value value, const std::string& subKey);
+    template<typename T>
+    void setJsonArray(const std::string& key, const std::vector<T>& array);
+
+private:
+    Json::Value mJson;
+    bool mIsInitialized;
+};
+} // namespace orb
+
+#endif // JSONIMPL_H

--- a/orblibrary/include/Moderator.h
+++ b/orblibrary/include/Moderator.h
@@ -19,19 +19,19 @@
 
 #include "IOrbBrowser.h"
 #include "OrbConstants.h"
+#include "IJson.h"
+#include "IFactory.h"
 
 namespace orb
 {
 
-class Network;
-class MediaSynchroniser;
-class AppMgrInterface;
-class Drm;
+class ComponentBase;
+class IAppMgrInterface;
 
 class Moderator
 {
 public:
-    Moderator(IOrbBrowser* browser, ApplicationType apptype);
+    Moderator(IOrbBrowser* browser, ApplicationType apptype, std::unique_ptr<IFactory> factory);
     ~Moderator();
 
     // ----------------------------------------------------------
@@ -69,10 +69,11 @@ public:
 
 private:
     IOrbBrowser *mOrbBrowser;
-    std::unique_ptr<Network> mNetwork;
-    std::unique_ptr<MediaSynchroniser> mMediaSynchroniser;
-    std::unique_ptr<AppMgrInterface> mAppMgrInterface;
-    std::unique_ptr<Drm> mDrm;
+    std::unique_ptr<IFactory> mFactory;
+    std::unique_ptr<ComponentBase> mNetwork;
+    std::unique_ptr<ComponentBase> mMediaSynchroniser;
+    std::unique_ptr<IAppMgrInterface> mAppMgrInterface;
+    std::unique_ptr<ComponentBase> mDrm;
     ApplicationType mAppType;
 }; // class Moderator
 

--- a/orblibrary/moderator/AppMgrInterface.hpp
+++ b/orblibrary/moderator/AppMgrInterface.hpp
@@ -16,18 +16,52 @@
 #pragma once
 
 #include <string>
-
-#include <json/json.h>
-
 #include "Moderator.h"
 #include "ComponentBase.hpp"
 #include "app_mgr/application_session_callback.h"
 
 namespace orb
 {
-class ApplicationManager;
 
-class AppMgrInterface : ComponentBase, public ApplicationSessionCallback
+/**
+ * Interface for the AppMgrInterface class.
+ */
+class IAppMgrInterface : public ComponentBase, public ApplicationSessionCallback {
+public:
+    virtual ~IAppMgrInterface() = default;
+
+    /**
+     * Callback for network status change
+     *
+     * @param available True if the network is available, false otherwise
+     */
+    virtual void onNetworkStatusChange(bool available) = 0;
+
+    /**
+     * Callback for channel change
+     *
+     * @param onetId The ONET ID
+     * @param transId The transport stream ID
+     * @param serviceId The service ID
+     */
+    virtual void onChannelChange(uint16_t onetId, uint16_t transId, uint16_t serviceId) = 0;
+    /**
+     * Process an AIT section
+     *
+     * @param aitPid The AIT PID
+     * @param serviceId The service ID
+     * @param section The AIT section to process
+     */
+    virtual void processAitSection(int32_t aitPid, int32_t serviceId, const std::vector<uint8_t>& section) = 0;
+    /**
+     * Process an XML AIT
+     *
+     * @param xmlait The XML AIT to process
+     */
+    virtual void processXmlAit(const std::vector<uint8_t>& xmlait) = 0;
+};
+
+class AppMgrInterface : public IAppMgrInterface
 {
 public:
     // constructor for explicit Application Type
@@ -42,12 +76,12 @@ public:
      *
      * @return JSON encoded response string
      */
-    std::string executeRequest(std::string method, Json::Value token, Json::Value params) override;
+    std::string executeRequest(std::string method, std::string token, std::unique_ptr<IJson> params) override;
 
-    void onNetworkStatusChange(bool available);
-    void onChannelChange(uint16_t onetId, uint16_t transId, uint16_t serviceId);
-    void processAitSection(int32_t aitPid, int32_t serviceId, const std::vector<uint8_t>& section);
-    void processXmlAit(const std::vector<uint8_t>& xmlait);
+    void onNetworkStatusChange(bool available) override;
+    void onChannelChange(uint16_t onetId, uint16_t transId, uint16_t serviceId) override;
+    void processAitSection(int32_t aitPid, int32_t serviceId, const std::vector<uint8_t>& section) override;
+    void processXmlAit(const std::vector<uint8_t>& xmlait) override;
 
     // ApplicationSessionCallback interface implementation
     void LoadApplication(const int appId, const char *entryUrl) override;

--- a/orblibrary/moderator/ComponentBase.hpp
+++ b/orblibrary/moderator/ComponentBase.hpp
@@ -16,7 +16,8 @@
 #pragma once
 
 #include <string>
-#include <json/json.h>
+#include "IJson.h"
+#include <memory>
 
 namespace orb
 {
@@ -25,7 +26,7 @@ class ComponentBase
 {
 public:
     ComponentBase() {}
-    virtual ~ComponentBase() {}
+    virtual ~ComponentBase() = default;
 
     ComponentBase (const ComponentBase&) = delete;
     ComponentBase& operator= (const ComponentBase&) = delete;
@@ -39,8 +40,7 @@ public:
      *
      * @return JSON encoded response string
      */
-    virtual std::string executeRequest(std::string method, Json::Value token, Json::Value params) = 0;
-
+    virtual std::string executeRequest(std::string method, std::string token, std::unique_ptr<IJson> params) = 0;
 }; // class ComponentBase
 
 } // namespace orb

--- a/orblibrary/moderator/Drm.cpp
+++ b/orblibrary/moderator/Drm.cpp
@@ -37,9 +37,18 @@ const string DRM_SYSTEM_ID = "DRMSystemID";
 const string DRM_PRIVATE_DATA = "DRMPrivateData";
 
 
-std::string Drm::executeRequest(std::string method, Json::Value token, Json::Value params)
+std::string Drm::executeRequest(std::string method, std::string token, std::unique_ptr<IJson> params)
 {
     LOGI("Drm executeRequest method: " << method);
+    // convert params to Json::Value, so we do not change other code.
+    // This is workaround for now, we need to change the code to use IJson instead of Json::Value
+    // in separate Ticket.
+
+    Json::Value paramsJson;
+    if (!JsonUtil::decodeJson(params->toString(), &paramsJson)) {
+        LOGE("Drm executeRequest: Invalid params");
+        return "{\"error\": \"Invalid params\"}";
+    }
 
     Json::Value response(Json::objectValue);
 
@@ -49,19 +58,19 @@ std::string Drm::executeRequest(std::string method, Json::Value token, Json::Val
     }
     else if (method == DRM_SEND_DRM_MESSAGE)
     {
-        response = handleSendDRMMessage(params);
+        response = handleSendDRMMessage(paramsJson);
     }
     else if (method == DRM_CAN_PLAY_CONTENT)
     {
-        response = handleCanPlayContent(params);
+        response = handleCanPlayContent(paramsJson);
     }
     else if (method == DRM_CAN_RECORD_CONTENT)
     {
-        response = handleCanRecordContent(params);
+        response = handleCanRecordContent(paramsJson);
     }
     else if (method == DRM_SET_ACTIVE_DRM)
     {
-        response = handleSetActiveDRM(params);
+        response = handleSetActiveDRM(paramsJson);
     }
     else
     {

--- a/orblibrary/moderator/Drm.hpp
+++ b/orblibrary/moderator/Drm.hpp
@@ -39,7 +39,7 @@ public:
      *
      * @return JSON encoded response string
      */
-    std::string executeRequest(std::string method, Json::Value token, Json::Value params) override;
+    std::string executeRequest(std::string method, std::string token, std::unique_ptr<IJson> params) override;
 
 private:
     /**

--- a/orblibrary/moderator/FactoryImpl.cpp
+++ b/orblibrary/moderator/FactoryImpl.cpp
@@ -1,0 +1,52 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Factory Implementation
+ *
+ * Note: This file implements the IFactory interface for creating ORB components.
+ */
+
+
+#include "FactoryImpl.h"
+#include "app_mgr/application_manager.h"
+#include "JsonImpl.h"
+#include "Drm.hpp"
+#include "AppMgrInterface.hpp"
+#include "log.h"
+#include "IOrbBrowser.h"
+
+namespace orb
+{
+
+std::unique_ptr<IJson> FactoryImpl::createJson(const std::string& jsonString)
+{
+    LOGI("FactoryImpl: Creating IJson instance");
+    return std::make_unique<JsonImpl>(jsonString);
+}
+
+std::unique_ptr<ComponentBase> FactoryImpl::createDrm()
+{
+    LOGI("FactoryImpl: Creating Drm instance");
+    return std::make_unique<Drm>();
+}
+
+std::unique_ptr<IAppMgrInterface> FactoryImpl::createAppMgrInterface(IOrbBrowser* browser, ApplicationType apptype)
+
+{
+    LOGI("FactoryImpl: Creating AppMgrInterface instance");
+    return std::make_unique<AppMgrInterface>(browser, apptype);
+}
+
+} // namespace orb

--- a/orblibrary/moderator/JsonImpl.cpp
+++ b/orblibrary/moderator/JsonImpl.cpp
@@ -1,0 +1,150 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "JsonImpl.h"
+#include "JsonUtil.h"
+
+namespace orb
+{
+    JsonImpl::JsonImpl() : mIsInitialized(false) {}
+
+    JsonImpl::JsonImpl(std::string jsonString) : mIsInitialized(false)
+    {
+        if (!jsonString.empty()) {
+            mIsInitialized = parse(jsonString);
+        }
+    }
+
+    JsonImpl::JsonImpl(Json::Value json)
+    {
+        mJson = json;
+        mIsInitialized = true;
+    }
+
+
+    bool JsonImpl::parse(std::string jsonString)
+    {
+
+        // initialize the Json::Value object with an empty json object
+        mJson = Json::Value();
+        mIsInitialized = JsonUtil::decodeJson(jsonString, &mJson);
+        return mIsInitialized;
+    }
+
+    bool JsonImpl::isInitialized()
+    {
+        return mIsInitialized;
+    }
+
+    bool JsonImpl::hasParam(const std::string &param, const JsonType& type)
+    {
+        return JsonUtil::HasParam(mJson, param, convertToJsonValueType(type));
+    }
+
+    std::string JsonImpl::toString()
+    {
+        return JsonUtil::convertJsonToString(mJson);
+    }
+
+    int JsonImpl::getInteger(const std::string& key)
+    {
+        return JsonUtil::getIntegerValue(mJson, key);
+    }
+
+    bool JsonImpl::getBool(const std::string& key)
+    {
+        return JsonUtil::getBoolValue(mJson, key);
+    }
+
+    std::string JsonImpl::getString(const std::string& key)
+    {
+        return JsonUtil::getStringValue(mJson, key);
+    }
+
+    std::unique_ptr<IJson> JsonImpl::getObject(const std::string& key)
+    {
+        return std::make_unique<JsonImpl>(mJson[key]);
+    }
+
+    Json::ValueType JsonImpl::convertToJsonValueType(const JsonType& type)
+    {
+        switch (type) {
+            case JsonType::JSON_TYPE_STRING:
+                return Json::stringValue;
+            case JsonType::JSON_TYPE_INTEGER:
+                return Json::intValue;
+            case JsonType::JSON_TYPE_BOOLEAN:
+                return Json::booleanValue;
+            case JsonType::JSON_TYPE_ARRAY:
+                return Json::arrayValue;
+            case JsonType::JSON_TYPE_OBJECT:
+                return Json::objectValue;
+        }
+        return Json::nullValue;
+    }
+
+    void JsonImpl::setInteger(const std::string& key, const int value, const std::string& subKey)
+    {
+        setValue(key, Json::Value(value), subKey);
+    }
+
+    void JsonImpl::setBool(const std::string& key, const bool value, const std::string& subKey)
+    {
+        setValue(key, Json::Value(value), subKey);
+    }
+
+    void JsonImpl::setString(const std::string& key, const std::string& value, const std::string& subKey)
+    {
+        setValue(key, Json::Value(value), subKey);
+    }
+
+    void JsonImpl::setValue(const std::string& key, Json::Value value, const std::string& subKey)
+    {
+        if (!subKey.empty()) {
+            mJson[key][subKey] = value;
+        }
+        else {
+            mJson[key] = value;
+        }
+    }
+
+    void JsonImpl::setArray(const std::string& key, const std::vector<uint16_t>& array)
+    {
+        setJsonArray(key, array);
+    }
+
+    void JsonImpl::setArray(const std::string& key, const std::vector<int>& array)
+    {
+        setJsonArray(key, array);
+    }
+
+    //  create a template function to set the array value
+    template<typename T>
+    void JsonImpl::setJsonArray(const std::string& key, const std::vector<T>& array)
+    {
+        Json::Value jsonArray(Json::arrayValue);
+        for (const auto& item : array)
+        {
+            jsonArray.append(item);
+        }
+        mJson[key] = jsonArray;
+    }
+
+    std::vector<uint16_t> JsonImpl::getUint16Array(const std::string& key)
+    {
+        return JsonUtil::getIntegerArray(mJson, key);
+    }
+
+}

--- a/orblibrary/moderator/MediaSynchroniser.cpp
+++ b/orblibrary/moderator/MediaSynchroniser.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 namespace orb
 {
-string MediaSynchroniser::executeRequest(string method, Json::Value token, Json::Value params)
+string MediaSynchroniser::executeRequest(string method, string token, std::unique_ptr<IJson> params)
 {
     // TODO Set up proper responses
     string response = R"({"Response": "MediaSynchroniser request [)" + method + R"(] not implemented"})";

--- a/orblibrary/moderator/MediaSynchroniser.hpp
+++ b/orblibrary/moderator/MediaSynchroniser.hpp
@@ -16,14 +16,12 @@
 #pragma once
 
 #include <string>
-#include <json/json.h>
-
 #include "ComponentBase.hpp"
 
 namespace orb
 {
 
-class MediaSynchroniser : ComponentBase
+class MediaSynchroniser : public ComponentBase
 {
 public:
     /**
@@ -35,7 +33,7 @@ public:
      *
      * @return JSON encoded response string
      */
-    std::string executeRequest(std::string method, Json::Value token, Json::Value params) override;
+    std::string executeRequest(std::string method, std::string token, std::unique_ptr<IJson> params) override;
 
 }; // class MediaSynchroniser
 

--- a/orblibrary/moderator/Network.hpp
+++ b/orblibrary/moderator/Network.hpp
@@ -16,17 +16,16 @@
 #pragma once
 
 #include <string>
-#include <json/json.h>
 
 #include "ComponentBase.hpp"
 
 namespace orb
 {
 
-class Network : ComponentBase
+class Network : public ComponentBase
 {
 public:
-    std::string executeRequest(std::string method, Json::Value token, Json::Value params) override;
+    std::string executeRequest(std::string method, std::string token, std::unique_ptr<IJson> params) override;
 
 }; // class Network
 

--- a/orblibrary/test/MockAppMgrInterface.h
+++ b/orblibrary/test/MockAppMgrInterface.h
@@ -1,0 +1,69 @@
+/**
+ * ORB Software. Copyright (c) 2022 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Mock AppMgrInterface for testing using Google Mock
+ */
+
+#ifndef MOCK_APP_MGR_INTERFACE_H
+#define MOCK_APP_MGR_INTERFACE_H
+
+#include "AppMgrInterface.hpp"
+#include "app_mgr/utils.h"
+#include <gmock/gmock.h>
+
+namespace orb
+{
+
+class MockAppMgrInterface : public IAppMgrInterface
+{
+public:
+    // Constructor - we need to provide a constructor that matches the base class
+    MockAppMgrInterface(IOrbBrowser* browser, ApplicationType apptype) : IAppMgrInterface() {}
+
+    virtual ~MockAppMgrInterface() = default;
+
+    // ComponentBase interface using Google Mock
+    MOCK_METHOD(std::string, executeRequest, (std::string method, std::string token, std::unique_ptr<IJson> params), (override));
+
+    // AppMgrInterface specific methods using Google Mock
+    MOCK_METHOD(void, onNetworkStatusChange, (bool available), (override));
+    MOCK_METHOD(void, onChannelChange, (uint16_t onetId, uint16_t transId, uint16_t serviceId), (override));
+    MOCK_METHOD(void, processAitSection, (int32_t aitPid, int32_t serviceId, const std::vector<uint8_t>& section), (override));
+    MOCK_METHOD(void, processXmlAit, (const std::vector<uint8_t>& xmlait), (override));
+
+    // ApplicationSessionCallback interface using Google Mock
+    MOCK_METHOD(void, LoadApplication, (const int appId, const char *entryUrl), (override));
+    MOCK_METHOD(void, LoadApplication, (const int appId, const char *entryUrl, int size, const std::vector<uint16_t> graphics), (override));
+    MOCK_METHOD(void, ShowApplication, (const int appId), (override));
+    MOCK_METHOD(void, HideApplication, (const int appId), (override));
+    MOCK_METHOD(void, StopBroadcast, (), (override));
+    MOCK_METHOD(void, ResetBroadcastPresentation, (), (override));
+    MOCK_METHOD(void, DispatchApplicationLoadErrorEvent, (), (override));
+    MOCK_METHOD(void, DispatchTransitionedToBroadcastRelatedEvent, (const int appId), (override));
+    MOCK_METHOD(std::string, GetXmlAitContents, (const std::string &url), (override));
+    MOCK_METHOD(int, GetParentalControlAge, (), (override));
+    MOCK_METHOD(std::string, GetParentalControlRegion, (), (override));
+    MOCK_METHOD(std::string, GetParentalControlRegion3, (), (override));
+    MOCK_METHOD(void, DispatchApplicationSchemeUpdatedEvent, (const int appId, const std::string &scheme), (override));
+    MOCK_METHOD(void, DispatchOperatorApplicationStateChange, (const int appId, const std::string &oldState, const std::string &newState), (override));
+    MOCK_METHOD(void, DispatchOperatorApplicationStateChangeCompleted, (const int appId, const std::string &oldState, const std::string &newState), (override));
+    MOCK_METHOD(void, DispatchOperatorApplicationContextChange, (const int appId, const std::string &startupLocation, const std::string &launchLocation), (override));
+    MOCK_METHOD(void, DispatchOpAppUpdate, (const int appId, const std::string &updateEvent), (override));
+    MOCK_METHOD(bool, isInstanceInCurrentService, (const Utils::S_DVB_TRIPLET &triplet), (override));
+};
+
+} // namespace orb
+
+#endif // MOCK_APP_MGR_INTERFACE_H

--- a/orblibrary/test/MockComponentBase.h
+++ b/orblibrary/test/MockComponentBase.h
@@ -13,34 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * ORB Network
- *
+ * Mock ComponentBase for testing using Google Mock
  */
 
-#include <sys/sysinfo.h>
+#ifndef MOCK_COMPONENT_BASE_H
+#define MOCK_COMPONENT_BASE_H
 
-#include "Network.hpp"
-#include "log.h"
-
-using namespace std;
+#include "ComponentBase.hpp"
+#include <gmock/gmock.h>
 
 namespace orb
 {
-string Network::executeRequest(string method, std::string token, std::unique_ptr<IJson> params)
+
+class MockComponentBase : public ComponentBase
 {
-    string response = R"({"Response": "Network request [)" + method + R"(] not implemented"})";
+public:
+    MockComponentBase() = default;
+    virtual ~MockComponentBase() = default;
 
-    if (method == "resolveHostAddress")
-    {
-        LOGI("method: " << method);
-    }
-    else // Unknown Method
-    {
-        response = R"({"error": "Network request [)" + method + R"(] invalid method"})";
-        LOGE("Invalid Method [" + method +"]");
-    }
-
-    return response;
-}
+    // ComponentBase interface using Google Mock
+    MOCK_METHOD(std::string, executeRequest, (std::string method, std::string token, std::unique_ptr<IJson> params), (override));
+};
 
 } // namespace orb
+
+#endif // MOCK_COMPONENT_BASE_H

--- a/orblibrary/test/MockFactory.h
+++ b/orblibrary/test/MockFactory.h
@@ -1,0 +1,49 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Mock Factory Implementation
+ *
+ * Note: This file provides mock implementations for testing the IFactory interface.
+ */
+
+#ifndef MOCK_FACTORY_H
+#define MOCK_FACTORY_H
+
+#include "IFactory.h"
+#include "MockJson.h"
+#include <gmock/gmock.h>
+#include <memory>
+
+namespace orb
+{
+
+/**
+ * Mock implementation of IFactory using Google Mock
+ */
+class MockFactory : public IFactory
+{
+public:
+    MOCK_METHOD(std::unique_ptr<IJson>, createJson, (const std::string& jsonString), (override));
+
+    MOCK_METHOD(std::unique_ptr<ComponentBase>, createDrm, (), (override));
+
+    MOCK_METHOD(std::unique_ptr<IAppMgrInterface>, createAppMgrInterface, (IOrbBrowser* browser, ApplicationType apptype), (override));
+
+};
+
+
+} // namespace orb
+
+#endif // MOCK_FACTORY_H

--- a/orblibrary/test/MockJson.h
+++ b/orblibrary/test/MockJson.h
@@ -1,0 +1,51 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MOCKJSON_H
+#define MOCKJSON_H
+
+#include "IJson.h"
+#include <gmock/gmock.h>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace orb {
+
+/**
+ * Mock implementation of IJson interface for testing
+ */
+class MockJson : public IJson {
+public:
+    MOCK_METHOD(bool, isInitialized, (), (override));
+    MOCK_METHOD(bool, parse, (std::string jsonString), (override));
+    MOCK_METHOD(bool, hasParam, (const std::string& param, const JsonType& type), (override));
+    MOCK_METHOD(std::string, toString, (), (override));
+    MOCK_METHOD(int, getInteger, (const std::string& key), (override));
+    MOCK_METHOD(bool, getBool, (const std::string& key), (override));
+    MOCK_METHOD(std::string, getString, (const std::string& key), (override));
+    MOCK_METHOD(std::unique_ptr<IJson>, getObject, (const std::string& key), (override));
+    MOCK_METHOD(void, setInteger, (const std::string& key, const int value, const std::string& subKey), (override));
+    MOCK_METHOD(void, setBool, (const std::string& key, const bool value, const std::string& subKey), (override));
+    MOCK_METHOD(void, setString, (const std::string& key, const std::string& value, const std::string& subKey), (override));
+    MOCK_METHOD(void, setArray, (const std::string& key, const std::vector<uint16_t>& array), (override));
+    MOCK_METHOD(void, setArray, (const std::string& key, const std::vector<int>& array), (override));
+    MOCK_METHOD(std::vector<uint16_t>, getUint16Array, (const std::string& key), (override));
+};
+
+
+} // namespace orb
+
+#endif // MOCKJSON_H

--- a/orblibrary/test/MockOrbBrowser.h
+++ b/orblibrary/test/MockOrbBrowser.h
@@ -1,47 +1,44 @@
+/**
+ * ORB Software. Copyright (c) 2025 Ocean Blue Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef MOCKORBBROWSER_H
 #define MOCKORBBROWSER_H
 
 #include "IOrbBrowser.h"
-#include "JsonUtil.h"
+#include <gmock/gmock.h>
 #include <string>
 #include <vector>
 
-class MockOrbBrowser : public orb::IOrbBrowser {
-    public:
-    void loadApplication(std::string app_id, std::string url) override {
-     // TODO: implement
-    }
-    void showApplication() override {
-     // TODO: implement
-    }
-    void hideApplication() override {
-     // TODO: implement
-    }
-    std::string sendRequestToClient(std::string jsonRequest) override {
-     // get the method from the jsonRequest
-     Json::Value jsonRequestVal;
-     if (!orb::JsonUtil::decodeJson(jsonRequest, &jsonRequestVal)) {
-         return "{\"result\":{\"error\":\"Invalid JSON request\"}}";
-     }
-     std::string method = jsonRequestVal["method"].asString();
-     if (method == "Configuration.getCapabilities") {
-         return "{\"result\":{\"jsonRpcServerEndpoint\":\"/hbbtv/jsonrpc/\",\"jsonRpcServerPort\":8080}}";
-     }
-     else if (method == "Configuration.getAudioProfiles") {
-         return "{\"result\":{\"AudioProfiles\":[{\"name\":\"AudioProfile1\",\"id\":1},{\"name\":\"AudioProfile2\",\"id\":2}]}}";
-     }
-     else if (method == "Configuration.getVideoProfiles") {
-         return "{\"result\":{\"VideoProfiles\":[{\"name\":\"VideoProfile1\",\"id\":1},{\"name\":\"VideoProfile2\",\"id\":2}]}}";
-     } else if (method == "VideoWindow.ChannelStatusChanged") {
-         return jsonRequest;
-     }
-     return "{\"result\":{\"error\":\"Not implemented\"}}";
-    }
-    void dispatchEvent(const std::string& etype, const std::string& properties) override {
-     // TODO: implement
-    }
-    void notifyKeySetChange(uint16_t keyset, std::vector<uint16_t> otherkeys) override {
-    }
- };
+namespace orb
+{
 
-#endif
+/**
+ * Mock implementation of IOrbBrowser using Google Mock
+ */
+class MockOrbBrowser : public IOrbBrowser
+{
+public:
+    MOCK_METHOD(void, loadApplication, (std::string app_id, std::string url), (override));
+    MOCK_METHOD(void, showApplication, (), (override));
+    MOCK_METHOD(void, hideApplication, (), (override));
+    MOCK_METHOD(std::string, sendRequestToClient, (std::string jsonRequest), (override));
+    MOCK_METHOD(void, dispatchEvent, (const std::string& etype, const std::string& properties), (override));
+    MOCK_METHOD(void, notifyKeySetChange, (uint16_t keyset, (std::vector<uint16_t>) otherkeys), (override));
+};
+
+} // namespace orb
+
+#endif // MOCKORBBROWSER_H

--- a/orblibrary/test/moderator_unittest.cpp
+++ b/orblibrary/test/moderator_unittest.cpp
@@ -1,168 +1,297 @@
 #include <iostream>
 #include <string>
+#include <memory>
 
 #include "testing/gtest/include/gtest/gtest.h"
-#include "third_party/orb/orblibrary/include/Moderator.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "Moderator.h"
+#include "MockOrbBrowser.h"
+#include "MockJson.h"
+#include "MockFactory.h"
+#include "MockAppMgrInterface.h"
+#include "MockComponentBase.h"
 
-TEST(OrbModerator, TestModeratorInvalidRequest)
+
+/**
+ * Test fixture class for Moderator unit tests
+ * Provides common setup and helper methods for all test cases
+ */
+class ModeratorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create mock objects
+        mockBrowser = std::make_unique<orb::MockOrbBrowser>();
+        mockFactory = std::make_unique<orb::MockFactory>();
+        mockAppMgrInterface = std::make_unique<orb::MockAppMgrInterface>(mockBrowser.get(), orb::APP_TYPE_HBBTV);
+        mockDrm = std::make_unique<orb::MockComponentBase>();
+    }
+
+    void TearDown() override {}
+
+    /**
+     * Create a Moderator instance with the current mock objects
+     */
+    std::unique_ptr<orb::Moderator> createModerator() {
+        return std::make_unique<orb::Moderator>(
+            mockBrowser.get(),
+            orb::APP_TYPE_HBBTV,
+            std::move(mockFactory)
+        );
+    }
+
+    void createAppMgrInterfaceAndDrm() {
+      EXPECT_CALL(*mockFactory, createAppMgrInterface(mockBrowser.get(), orb::APP_TYPE_HBBTV))
+         .WillOnce(::testing::Return(::testing::ByMove(std::move(mockAppMgrInterface))));
+      EXPECT_CALL(*mockFactory, createDrm())
+         .WillOnce(::testing::Return(::testing::ByMove(std::move(mockDrm))));
+    }
+
+    void setupJsonParsing(const std::string& input, bool parseResult, const std::string& methodValue = "") {
+        auto mockJson = std::make_unique<orb::MockJson>();
+        EXPECT_CALL(*mockJson, parse(input))
+            .WillOnce(::testing::Return(parseResult));
+
+        if (!methodValue.empty()) {
+            EXPECT_CALL(*mockJson, getString("method"))
+             .WillOnce(::testing::Return(methodValue));
+        }
+
+        EXPECT_CALL(*mockFactory, createJson(""))
+            .WillOnce(::testing::Return(::testing::ByMove(std::move(mockJson))));
+        createAppMgrInterfaceAndDrm();
+    }
+
+    /**
+     * Set up expectations for error request handling
+     */
+    void setupErrorRequestHandling(const std::string& input) {
+      auto mockJson = std::make_unique<orb::MockJson>();
+        EXPECT_CALL(*mockJson, parse(input))
+            .WillOnce(::testing::Return(true));
+        EXPECT_CALL(*mockJson, hasParam("error", orb::JsonType::JSON_TYPE_OBJECT))
+            .WillOnce(::testing::Return(true));
+        EXPECT_CALL(*mockFactory, createJson(""))
+            .WillOnce(::testing::Return(::testing::ByMove(std::move(mockJson))));
+        createAppMgrInterfaceAndDrm();
+    }
+
+    /**
+     * Set up expectations for invalid method handling
+     */
+    void setupNoMethodHandling(const std::string& input) {
+      auto mockJson = std::make_unique<orb::MockJson>();
+      EXPECT_CALL(*mockJson, parse(input))
+            .WillOnce(::testing::Return(true));
+        EXPECT_CALL(*mockJson, hasParam("method", orb::JsonType::JSON_TYPE_STRING))
+            .WillOnce(::testing::Return(false));
+        EXPECT_CALL(*mockJson, hasParam("error", orb::JsonType::JSON_TYPE_OBJECT))
+            .WillOnce(::testing::Return(false));
+        EXPECT_CALL(*mockFactory, createJson(""))
+            .WillOnce(::testing::Return(::testing::ByMove(std::move(mockJson))));
+        createAppMgrInterfaceAndDrm();
+    }
+
+    /**
+     * Set up expectations for valid method handling
+     */
+    void setupHandleOrbRequest(const std::string& input, const std::string& methodValue, const std::string& resultValue) {
+        auto mockJson = std::make_unique<orb::MockJson>();
+        auto mockParams = std::make_unique<orb::MockJson>();
+        EXPECT_CALL(*mockJson, parse(input))
+            .WillOnce(::testing::Return(true));
+        EXPECT_CALL(*mockJson, getString("method"))
+            .WillOnce(::testing::Return(methodValue));
+        EXPECT_CALL(*mockJson, getString("token"))
+            .WillOnce(::testing::Return("token"));
+        EXPECT_CALL(*mockJson, hasParam("method", orb::JsonType::JSON_TYPE_STRING))
+            .WillOnce(::testing::Return(true));
+        EXPECT_CALL(*mockJson, hasParam("error", orb::JsonType::JSON_TYPE_OBJECT))
+            .WillOnce(::testing::Return(false));
+
+         int appType = orb::APP_TYPE_HBBTV;
+         EXPECT_CALL(*mockJson, setInteger("params",  appType, "applicationType"))
+            .WillOnce(::testing::Return());
+
+        EXPECT_CALL(*mockJson, getObject("params"))
+            .WillOnce(::testing::Return(::testing::ByMove(std::move(mockParams))));
+
+        EXPECT_CALL(*mockFactory, createJson(""))
+            .WillOnce(::testing::Return(::testing::ByMove(std::move(mockJson))));
+
+        createAppMgrInterfaceAndDrm();
+    }
+
+    void setupValidMethodHandlingForSendRequestToClient(const std::string& input, const std::string& methodValue, const std::string& resultValue) {
+      auto mockJson = std::make_unique<orb::MockJson>();
+      EXPECT_CALL(*mockJson, parse(input))
+          .WillOnce(::testing::Return(true));
+      EXPECT_CALL(*mockJson, getString("method"))
+          .WillOnce(::testing::Return(methodValue));
+      EXPECT_CALL(*mockJson, hasParam("method", orb::JsonType::JSON_TYPE_STRING))
+          .WillOnce(::testing::Return(true));
+      EXPECT_CALL(*mockJson, hasParam("error", orb::JsonType::JSON_TYPE_OBJECT))
+          .WillOnce(::testing::Return(false));
+      int appType = orb::APP_TYPE_HBBTV;
+      EXPECT_CALL(*mockJson, setInteger("params",  appType, "applicationType"))
+          .WillOnce(::testing::Return());
+      EXPECT_CALL(*mockJson, toString())
+          .WillOnce(::testing::Return(methodValue));
+
+      EXPECT_CALL(*mockBrowser, sendRequestToClient(methodValue))
+          .WillOnce(::testing::Return(resultValue));
+
+      EXPECT_CALL(*mockFactory, createJson(""))
+          .WillOnce(::testing::Return(::testing::ByMove(std::move(mockJson))));
+      createAppMgrInterfaceAndDrm();
+    }
+
+    // Mock objects available to all test methods
+    std::unique_ptr<orb::MockOrbBrowser> mockBrowser;
+    std::unique_ptr<orb::MockFactory> mockFactory;
+    std::unique_ptr<orb::MockAppMgrInterface> mockAppMgrInterface;
+    std::unique_ptr<orb::MockComponentBase> mockDrm;
+};
+
+TEST_F(ModeratorTest, HandleOrbRequestEmptyRequest)
 {
-  // GIVEN: an orb::Moderator object
-  orb::Moderator moderator;
-
-  // WHEN: executeRequest is called with an empty string
-  std::string response = moderator.executeRequest("");
-
-  // THEN: an invalid JSON error reponse is returned
-  EXPECT_EQ(response, R"({"error": "Invalid Request"})");
-
-  // OR WHEN: executeRequest is called without a method argument
-  response = moderator.executeRequest(R"({ "NotAMethod": { "Some": "Value" }})");
-
-  // THEN: an invalid method reponse is returned
-  EXPECT_EQ(response, R"({"error": "No method"})");
-
-  // OR WHEN: executeRequest is called with valid JSON with an invalid method parameter,
-  std::string json_request = R"({ "method": { "Some": "Value" }})";
-
-  response = moderator.executeRequest(json_request);
-
-  // THEN: a JSON error reponse is returned
-  EXPECT_EQ(response, R"({"error": "No method"})");
+    setupJsonParsing("", false);
+    auto moderator = createModerator();
+    std::string response = moderator->handleOrbRequest("");
+    EXPECT_EQ(response, R"({"error": "Invalid Request"})");
 }
 
-TEST(OrbModerator, TestModeratorErrorRequest)
+TEST_F(ModeratorTest, HandleOrbRequestInvalidJsonRequest)
 {
-  // GIVEN: an orb::Moderator object
-  orb::Moderator moderator;
-
-  // WHEN: executeRequest is called with an "error" parameter string
-  std::string response = moderator.executeRequest(R"({ "error": { "Some": "Value" }})");
-
-  // THEN: a valid JSON error reponse is returned
-  EXPECT_EQ(response, R"({"error": "Error Request"})");
+    setupJsonParsing("invalid json", false);
+    auto moderator = createModerator();
+    std::string response = moderator->handleOrbRequest("invalid json");
+    EXPECT_EQ(response, R"({"error": "Invalid Request"})");
 }
 
-TEST(OrbModerator, TestModeratorInvalidMethod)
+TEST_F(ModeratorTest, HandleOrbRequestNoMethod)
 {
-  // GIVEN: an orb::Moderator object
-  orb::Moderator moderator;
-
-  // WHEN: executeRequest is called with a invalid method request
-  std::string response = moderator.executeRequest(R"({ "method": "some method" })");
-
-  // THEN: a valid JSON reponse is returned indicating an invalid method
-  EXPECT_EQ(response, R"({"error": "Invalid method"})");
+    setupNoMethodHandling(R"({ "NotAMethod": { "Some": "Value" }})");
+    auto moderator = createModerator();
+    std::string response = moderator->handleOrbRequest(R"({ "NotAMethod": { "Some": "Value" }})");
+    EXPECT_EQ(response, R"({"error": "No method"})");
 }
 
-TEST(OrbModerator, TestModeratorValidMethod_AppManager)
+TEST_F(ModeratorTest, HandleOrbRequestErrorRequest)
 {
-  // GIVEN: an orb::Moderator object
-  orb::Moderator moderator;
-
-  // WHEN: executeRequest is called with a valid 'Manager' component payload
-  // but invalid 'method'
-  std::string response = moderator.executeRequest(R"({ "method": "Manager.SomeMethod" })");
-
-  // THEN: a valid JSON reponse is returned indicating an invalid method
-  EXPECT_EQ(response, R"({"error": "AppManager request [SomeMethod] invalid method"})");
-
-  // AND WHEN: executeRequest is called with a valid 'Manager' method payload
-  std::vector<std::string> requests = {
-    "createApplication",
-    "destroyApplication",
-    "showApplication",
-    "hideApplication",
-    "searchOwner",
-    "getFreeMem",
-    "getKeyIcon",
-    "setKeyValue",
-    "getKeyMaximumValue",
-    "getKeyValues",
-    "getApplicationScheme",
-    "getApplicationUrl",
-    "getRunningAppIds"
-  };
-
-  for (const auto& request : requests)
-  {
-    std::string json_request = R"({ "method": "Manager.)" + request + R"(" })";
-    response = moderator.executeRequest(json_request);
-
-    // THEN: a valid JSON reponse is returned
-    EXPECT_EQ(response, R"({"Response": "AppManager request [)" + request + R"(] not implemented"})");
-  }
+    setupErrorRequestHandling(R"({ "error": { "Some": "Value" }})");
+    auto moderator = createModerator();
+    std::string response = moderator->handleOrbRequest(R"({ "error": { "Some": "Value" }})");
+    EXPECT_EQ(response, R"({"error": "Error Request"})");
 }
 
-TEST(OrbModerator, TestModeratorValidMethod_Network)
+TEST_F(ModeratorTest, HandleOrbRequestForApplicationManager)
 {
-  // GIVEN: an orb::Moderator object
-  orb::Moderator moderator;
-
-  // WHEN: executeRequest is called with a valid 'Network' component payload
-  // but invalid 'method'
-  std::string response = moderator.executeRequest(R"({ "method": "Network.SomeMethod" })");
-
-  // THEN: a valid JSON reponse is returned indicating an invalid method
-  EXPECT_EQ(response, R"({"error": "Network request [SomeMethod] invalid method"})");
-
-  // AND WHEN: executeRequest is called with a valid 'Network' method payload
-  std::vector<std::string> requests = {
-    "resolveHostAddress"
-  };
-
-  for (const auto& request : requests)
-  {
-    std::string json_request = R"({ "method": "Network.)" + request + R"(" })";
-    response = moderator.executeRequest(json_request);
-
-    // THEN: a valid JSON reponse is returned
-    EXPECT_EQ(response, R"({"Response": "Network request [)" + request + R"(] not implemented"})");
-  }
+    EXPECT_CALL(*mockAppMgrInterface, executeRequest("showApplication", "token", ::testing::_))
+        .WillOnce(::testing::Return(R"({"result": ""})"));
+    setupHandleOrbRequest(R"({ "method": "Manager.showApplication" })", "Manager.showApplication", R"({"result": ""})");
+    auto moderator = createModerator();
+    std::string response = moderator->handleOrbRequest(R"({ "method": "Manager.showApplication" })");
+    EXPECT_EQ(response, R"({"result": ""})");
 }
 
-TEST(OrbModerator, TestModeratorValidMethod_MediaSynchroniser)
+TEST_F(ModeratorTest, HandleOrbRequestForDrm)
 {
-  // GIVEN: an orb::Moderator object
-  orb::Moderator moderator;
-
-  // WHEN: executeRequest is called with a valid 'MediaSynchroniser' component payload
-  // but invalid 'method'
-  std::string response = moderator.executeRequest(R"({ "method": "MediaSynchroniser.SomeMethod" })");
-
-  // THEN: a valid JSON reponse is returned indicating an invalid method
-  EXPECT_EQ(response, R"({"error": "MediaSynchroniser request [SomeMethod] invalid method"})");
-
-  // AND WHEN: executeRequest is called with a valid 'Network' method payload
-  std::vector<std::string> requests = {
-    "instantiate",
-    "initialise",
-    "destroy",
-    "enableInterDeviceSync",
-    "disableInterDeviceSync",
-    "nrOfSlaves",
-    "interDeviceSyncEnabled",
-    "getContentIdOverride",
-    "getBroadcastCurrentTime",
-    "startTimelineMonitoring",
-    "stopTimelineMonitoring",
-    "setContentIdOverride",
-    "setContentTimeAndSpeed",
-    "updateCssCiiProperties",
-    "setTimelineAvailability"
-  };
-
-  for (const auto& request : requests)
-  {
-    std::string json_request = R"({ "method": "MediaSynchroniser.)" + request + R"(" })";
-    response = moderator.executeRequest(json_request);
-
-    // THEN: a valid JSON reponse is returned
-    EXPECT_EQ(response, R"({"Response": "MediaSynchroniser request [)" + request + R"(] not implemented"})");
-  }
+    EXPECT_CALL(*mockDrm, executeRequest("setActiveDRM", "token", ::testing::_))
+        .WillOnce(::testing::Return(R"({"result": false})"));
+    setupHandleOrbRequest(R"({ "method": "Drm.setActiveDRM" })", "Drm.setActiveDRM", R"({"result": false})");
+    auto moderator = createModerator();
+    std::string response = moderator->handleOrbRequest(R"({ "method": "Drm.setActiveDRM" })");
+    EXPECT_EQ(response, R"({"result": false})");
 }
 
+TEST_F(ModeratorTest, HandleOrbRequestForNetwork)
+{
+    std::string result = R"({"Response": "Network request [resolveHostAddress] not implemented"})";
+    setupHandleOrbRequest(R"({ "method": "Network.resolveHostAddress" })", "Network.resolveHostAddress", result);
+    auto moderator = createModerator();
+    std::string response = moderator->handleOrbRequest(R"({ "method": "Network.resolveHostAddress" })");
+    EXPECT_EQ(response, result);
+}
 
-// TODO add tests for
+TEST_F(ModeratorTest, HandleOrbRequestForSendRequestToClient)
+{
+    std::string result = R"({"result": "OrbClient Response"})";
+    setupValidMethodHandlingForSendRequestToClient(R"({ "method": "Broadcast.SetChannel" })", "Broadcast.SetChannel", result);
+    auto moderator = createModerator();
+    std::string response = moderator->handleOrbRequest(R"({ "method": "Broadcast.SetChannel" })");
+    EXPECT_EQ(response, result);
+}
 
-// - DVB client? Null DVB client
+// add test to test handleBridgeEvent
+TEST_F(ModeratorTest, HandleBridgeEventForChannelStatusChange)
+{
+    std::string etype = orb::CHANNEL_STATUS_CHANGE;
+    std::string properties = R"({ "statusCode": -2, "onetId": 1, "transId": 1, "servId": 1 })";
+    auto mockJson = std::make_unique<orb::MockJson>();
+    EXPECT_CALL(*mockJson, parse(properties))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockJson, getInteger("statusCode"))
+        .WillOnce(::testing::Return(orb::CHANNEL_STATUS_CONNECTING));
+    EXPECT_CALL(*mockJson, getInteger("onetId"))
+        .WillOnce(::testing::Return(1));
+    EXPECT_CALL(*mockJson, getInteger("transId"))
+        .WillOnce(::testing::Return(1));
+    EXPECT_CALL(*mockJson, getInteger("servId"))
+        .WillOnce(::testing::Return(1));
 
+    EXPECT_CALL(*mockFactory, createJson(""))
+      .WillOnce(::testing::Return(::testing::ByMove(std::move(mockJson))));
+
+    EXPECT_CALL(*mockAppMgrInterface, onChannelChange(1, 1, 1))
+        .WillOnce(::testing::Return());
+
+    createAppMgrInterfaceAndDrm();
+    auto moderator = createModerator();
+    bool consumed = moderator->handleBridgeEvent(etype, properties);
+    EXPECT_FALSE(consumed);
+}
+
+TEST_F(ModeratorTest, HandleBridgeEventForNetworkStatusChange)
+{
+    std::string etype = orb::NETWORK_STATUS;
+    std::string properties = R"({ "available": true })";
+    auto mockJson = std::make_unique<orb::MockJson>();
+    EXPECT_CALL(*mockJson, parse(properties))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockJson, getBool("available"))
+        .WillOnce(::testing::Return(true));
+
+    EXPECT_CALL(*mockFactory, createJson(""))
+        .WillOnce(::testing::Return(::testing::ByMove(std::move(mockJson))));
+
+    EXPECT_CALL(*mockAppMgrInterface, onNetworkStatusChange(true))
+        .WillOnce(::testing::Return());
+
+    createAppMgrInterfaceAndDrm();
+    auto moderator = createModerator();
+    bool consumed = moderator->handleBridgeEvent(etype, properties);
+    EXPECT_TRUE(consumed);
+}
+
+TEST_F(ModeratorTest, ProcessAitSection)
+{
+  const std::vector<uint8_t>& section =
+  {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+  EXPECT_CALL(*mockAppMgrInterface, processAitSection(1, 1, section))
+      .WillOnce(::testing::Return());
+
+  createAppMgrInterfaceAndDrm();
+  auto moderator = createModerator();
+  moderator->processAitSection(1, 1, section);
+}
+
+TEST_F(ModeratorTest, ProcessXmlAit)
+{
+  const std::vector<uint8_t>& xmlait =
+  {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+  EXPECT_CALL(*mockAppMgrInterface, processXmlAit(xmlait))
+      .WillOnce(::testing::Return());
+  createAppMgrInterfaceAndDrm();
+  auto moderator = createModerator();
+  moderator->processXmlAit(xmlait);
+}

--- a/orblibrary/test/video_window_unittest.cpp
+++ b/orblibrary/test/video_window_unittest.cpp
@@ -8,6 +8,7 @@
 #include "MockOrbBrowser.h"
 #include "JsonRpcService.h"
 #include "OrbConstants.h"
+#include "JsonUtil.h"
 
 
 using namespace orb;
@@ -105,6 +106,9 @@ TEST_F(VideoWindowTest, TestDispatchChannelStatusChangedEventConnecting) {
     Json::Value params;
     params["status"] = 1; // PLAYBACK_STATUS_CONNECTING
 
+    EXPECT_CALL(*m_mockOrbBrowser, sendRequestToClient(::testing::_))
+        .WillOnce(::testing::Return("{\"method\":\"VideoWindow.ChannelStatusChanged\",\"params\":{\"statusCode\":-2}}"));
+
     std::string result = m_videoWindow->DispatchChannelStatusChangedEvent(params);
 
     // Verify the result contains the expected status code
@@ -119,6 +123,9 @@ TEST_F(VideoWindowTest, TestDispatchChannelStatusChangedEventPresenting) {
     // Test dispatching channel status changed event for presenting status
     Json::Value params;
     params["status"] = 2; // PLAYBACK_STATUS_PRESENTING
+
+    EXPECT_CALL(*m_mockOrbBrowser, sendRequestToClient(::testing::_))
+        .WillOnce(::testing::Return("{\"method\":\"VideoWindow.ChannelStatusChanged\",\"params\":{\"statusCode\":-3}}"));
 
     std::string result = m_videoWindow->DispatchChannelStatusChangedEvent(params);
 
@@ -135,6 +142,9 @@ TEST_F(VideoWindowTest, TestDispatchChannelStatusChangedEventStopped) {
     Json::Value params;
     params["status"] = 3; // PLAYBACK_STATUS_STOPPED
 
+    EXPECT_CALL(*m_mockOrbBrowser, sendRequestToClient(::testing::_))
+        .WillOnce(::testing::Return("{\"method\":\"VideoWindow.ChannelStatusChanged\",\"params\":{\"statusCode\":6}}"));
+
     std::string result = m_videoWindow->DispatchChannelStatusChangedEvent(params);
 
     // Verify the result contains the expected status code
@@ -150,6 +160,9 @@ TEST_F(VideoWindowTest, TestDispatchChannelStatusChangedEventWithError) {
     Json::Value params;
     params["status"] = 1;
     params["error"] = CHANNEL_STATUS_NO_SIGNAL;
+
+    EXPECT_CALL(*m_mockOrbBrowser, sendRequestToClient(::testing::_))
+        .WillOnce(::testing::Return("{\"method\":\"VideoWindow.ChannelStatusChanged\",\"params\":{\"statusCode\":1,\"permanentError\":true}}"));
 
     std::string result = m_videoWindow->DispatchChannelStatusChangedEvent(params);
 


### PR DESCRIPTION
1. Ticket link: https://oceanbluesoftware.atlassian.net/browse/FREE-283
2. Create IJson interface to remove Json lib dependency in moderator
3. Create IAppMgrInterface to remove dependency to AppMgrInterface implementation which will use JsonUtil and ApplicationManager singleton
4. Create AppMgrInterface, Drm and IJson objects with IFactory interface. so Mock class can be injected in Unit tests
5. Rewrite all test cases of Moderator with GMock
6. Fix compiling error for VideoWindow as MockOrbBrowser has been re-implemented with GMock
Note: this change will lead to Chromium project build failed as A new parameter "Factory" is needed when creating moderator in Shell.   
