### PR TITLE
Coit 105: Destruction of the Websocket server was not thread safe.

### DIFF
--- a/android/mockdialservice/CMakeLists.txt
+++ b/android/mockdialservice/CMakeLists.txt
@@ -12,7 +12,7 @@ if (CMAKE_CURRENT_BINARY_DIR MATCHES "debug")
 endif()
 
 include_directories(
-   src/main/symlink.mock_dial_service/
+   ../../components/mock_dial_service/
 )
 
 find_library(log-lib log)
@@ -20,11 +20,11 @@ find_library(android-lib android)
 
 add_library(
    org.orbtv.mockdialservice.mockdialservice STATIC
-   src/main/symlink.mock_dial_service/url_lib.c
-   src/main/symlink.mock_dial_service/dial_data.c
-   src/main/symlink.mock_dial_service/dial_server.c
-   src/main/symlink.mock_dial_service/quick_ssdp.c
-   src/main/symlink.mock_dial_service/mongoose.c
+   ../../components/mock_dial_service/url_lib.c
+   ../../components/mock_dial_service/dial_data.c
+   ../../components/mock_dial_service/dial_server.c
+   ../../components/mock_dial_service/quick_ssdp.c
+   ../../components/mock_dial_service/mongoose.c
 )
 
 add_library(

--- a/android/mockdialservice/src/main/Android.mk
+++ b/android/mockdialservice/src/main/Android.mk
@@ -20,5 +20,9 @@ LOCAL_CERTIFICATE := platform
 LOCAL_PROGUARD_ENABLED := disabled
 
 include $(BUILD_PACKAGE)
-include $(call all-makefiles-under, $(LOCAL_PATH))
+
+ORB_COMPONENT_PATH := $(LOCAL_PATH)/../../../../components
+#include $(call all-makefiles-under,$(LOCAL_PATH))
+include $(LOCAL_PATH)/cpp/Android.mk
+include $(ORB_COMPONENT_PATH)/mock_dial_service/Android.mk
 

--- a/android/mockdialservice/src/main/cpp/Android.mk
+++ b/android/mockdialservice/src/main/cpp/Android.mk
@@ -17,7 +17,7 @@ LOCAL_CFLAGS := -Wno-unused-parameter \
    -Wno-unused-private-field
 
 LOCAL_C_INCLUDES := \
-   $(LOCAL_PATH)/../symlink.mock_dial_service/
+   $(LOCAL_PATH)/../../../../../components/mock_dial_service/
    
 LOCAL_STATIC_LIBRARIES := \
    liborg.dtvkit.inputsource.mockdialservice \

--- a/android/mockdialservice/src/main/symlink.mock_dial_service
+++ b/android/mockdialservice/src/main/symlink.mock_dial_service
@@ -1,1 +1,0 @@
-../../../../components/mock_dial_service

--- a/android/orblibrary/CMakeLists.txt
+++ b/android/orblibrary/CMakeLists.txt
@@ -14,11 +14,11 @@ add_definitions(-DLWS_VERSION_4=1)
 include_directories(
    build/prebuilts/libxml2/include
    build/prebuilts/libwebsockets/include
-   src/main/symlink.network_services
-   src/main/symlink.network_services/media_synchroniser
-   src/main/symlink.network_services/app2app
-   src/main/symlink.network_services/json_rpc
-   src/main/symlink.application_manager
+   ../../components/network_services
+   ../../components/network_services/media_synchroniser
+   ../../components/network_services/app2app
+   ../../components/network_services/json_rpc
+   ../../components/application_manager
 )
 
 find_library(log-lib log)
@@ -43,11 +43,11 @@ set_target_properties(
 add_library(
    org.orbtv.orblibrary.applicationmanager STATIC
    # sources...
-   src/main/symlink.application_manager/application_manager.cpp
-   src/main/symlink.application_manager/utils.cpp
-   src/main/symlink.application_manager/ait.cpp
-   src/main/symlink.application_manager/xml_parser.cpp
-   src/main/symlink.application_manager/app.cpp
+   ../../components/application_manager/application_manager.cpp
+   ../../components/application_manager/utils.cpp
+   ../../components/application_manager/ait.cpp
+   ../../components/application_manager/xml_parser.cpp
+   ../../components/application_manager/app.cpp
 )
 target_link_libraries(
    org.orbtv.orblibrary.applicationmanager
@@ -55,29 +55,29 @@ target_link_libraries(
 
 set(
     NETWORK_SERVICES_SOURCE_FILES
-    "src/main/symlink.network_services/app2app/app2app_local_service.cpp"
-    "src/main/symlink.network_services/app2app/app2app_remote_service.cpp"
-    "src/main/symlink.network_services/media_synchroniser/media_synchroniser.cpp"
-    "src/main/symlink.network_services/media_synchroniser/Correlation.cpp"
-    "src/main/symlink.network_services/media_synchroniser/CorrelatedClock.cpp"
-    "src/main/symlink.network_services/media_synchroniser/ClockBase.cpp"
-    "src/main/symlink.network_services/media_synchroniser/SysClock.cpp"
-    "src/main/symlink.network_services/media_synchroniser/ClockUtilities.cpp"
-    "src/main/symlink.network_services/service_manager.cpp"
-    "src/main/symlink.network_services/UdpSocketService.cpp"
-    "src/main/symlink.network_services/websocket_service.cpp"
-    "src/main/symlink.network_services/media_synchroniser/WallClockService.cpp"
-    "src/main/symlink.network_services/media_synchroniser/Nullable.h"
-    "src/main/symlink.network_services/media_synchroniser/ContentIdentificationService.cpp"
-    "src/main/symlink.network_services/media_synchroniser/CSSUtilities.cpp"
-    "src/main/symlink.network_services/media_synchroniser/TimelineSyncService.cpp"
+    "../../components/network_services/app2app/app2app_local_service.cpp"
+    "../../components/network_services/app2app/app2app_remote_service.cpp"
+    "../../components/network_services/media_synchroniser/media_synchroniser.cpp"
+    "../../components/network_services/media_synchroniser/Correlation.cpp"
+    "../../components/network_services/media_synchroniser/CorrelatedClock.cpp"
+    "../../components/network_services/media_synchroniser/ClockBase.cpp"
+    "../../components/network_services/media_synchroniser/SysClock.cpp"
+    "../../components/network_services/media_synchroniser/ClockUtilities.cpp"
+    "../../components/network_services/service_manager.cpp"
+    "../../components/network_services/UdpSocketService.cpp"
+    "../../components/network_services/websocket_service.cpp"
+    "../../components/network_services/media_synchroniser/WallClockService.cpp"
+    "../../components/network_services/media_synchroniser/Nullable.h"
+    "../../components/network_services/media_synchroniser/ContentIdentificationService.cpp"
+    "../../components/network_services/media_synchroniser/CSSUtilities.cpp"
+    "../../components/network_services/media_synchroniser/TimelineSyncService.cpp"
 )
 
 if(DEFINED ORB_HBBTV_VERSION AND ORB_HBBTV_VERSION GREATER_EQUAL 204)
     list(
         APPEND NETWORK_SERVICES_SOURCE_FILES
-        "src/main/symlink.network_services/json_rpc/JsonRpcService.h"
-        "src/main/symlink.network_services/json_rpc/JsonRpcService.cpp"
+        "../../components/network_services/json_rpc/JsonRpcService.h"
+        "../../components/network_services/json_rpc/JsonRpcService.cpp"
     )
 endif()
 

--- a/android/orblibrary/src/main/Android.mk
+++ b/android/orblibrary/src/main/Android.mk
@@ -42,5 +42,9 @@ LOCAL_PRODUCT_MODULE := true
 LOCAL_UNINSTALLABLE_MODULE := true
 include $(BUILD_PREBUILT)
 ##################################################
-include $(call all-makefiles-under,$(LOCAL_PATH))
+ORB_COMPONENT_PATH := $(LOCAL_PATH)/../../../../components
+#include $(call all-makefiles-under,$(LOCAL_PATH))
+include $(LOCAL_PATH)/cpp/Android.mk
+include $(ORB_COMPONENT_PATH)/application_manager/Android.mk
+include $(ORB_COMPONENT_PATH)/network_services/Android.mk
 

--- a/android/orblibrary/src/main/cpp/Android.mk
+++ b/android/orblibrary/src/main/cpp/Android.mk
@@ -11,19 +11,19 @@ endif
 
 ifeq ($(ORB_VENDOR), true)
     LOCAL_VENDOR_MODULE := true
-    
+
     LOCAL_SHARED_LIBRARIES := \
         libbase \
         libcutils \
         libutils \
         liblog
-    
+
     LOCAL_STATIC_LIBRARIES := \
         libcap \
         libssl \
         libcrypto_static \
         libjsoncpp_ORB
-        
+
     LOCAL_HEADER_LIBRARIES := jni_headers
 else
     LOCAL_SHARED_LIBRARIES := \
@@ -31,7 +31,7 @@ else
         libssl \
         libcrypto \
         libjsoncpp_ORB
-       
+
     LOCAL_STATIC_LIBRARIES := \
         liblog
 endif
@@ -41,16 +41,16 @@ LOCAL_SRC_FILES := \
    application_manager_native.cpp \
    network_services_native.cpp \
    native.cpp
-   
+
 LOCAL_C_INCLUDES := \
-   $(LOCAL_PATH)/../symlink.application_manager/ \
-   $(LOCAL_PATH)/../symlink.network_services/ \
-   $(LOCAL_PATH)/../symlink.network_services/media_synchroniser/ \
-   $(LOCAL_PATH)/../symlink.network_services/app2app/
-   
+   $(LOCAL_PATH)/../../../../../components/application_manager/ \
+   $(LOCAL_PATH)/../../../../../components/network_services/ \
+   $(LOCAL_PATH)/../../../../../components/network_services/media_synchroniser/ \
+   $(LOCAL_PATH)/../../../../../components/network_services/app2app/
+
 ifeq ($(ORB_HBBTV_VERSION),204)
 LOCAL_SRC_FILES += json_rpc_native.cpp
-LOCAL_C_INCLUDES += $(LOCAL_PATH)/../symlink.network_services/json_rpc/
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../../../../components/network_services/json_rpc/
 endif
 
 LOCAL_STATIC_LIBRARIES += liborg.orbtv.orblibrary.applicationmanager

--- a/android/orblibrary/src/main/symlink.application_manager
+++ b/android/orblibrary/src/main/symlink.application_manager
@@ -1,1 +1,0 @@
-../../../../components/application_manager

--- a/android/orblibrary/src/main/symlink.network_services
+++ b/android/orblibrary/src/main/symlink.network_services
@@ -1,1 +1,0 @@
-../../../../components/network_services

--- a/components/network_services/Android.mk
+++ b/components/network_services/Android.mk
@@ -4,12 +4,6 @@ include $(CLEAR_VARS)
 # Use jsoncpp_ORB or otherwise use default jsoncpp from source tree
 USE_JSONCPP_ORB ?= 1
 
-# Current jsoncpp version is 1.9.4 or above
-JSONCPP_VERSION_1_9_4 ?= 1
-
-# Support libwebsockets version 4.0 and above
-LWS_VERSION_4 ?= 1
-
 LOCAL_MODULE := liborg.orbtv.orblibrary.networkservices
 
 ifeq ($(ORB_HBBTV_VERSION),)
@@ -28,14 +22,14 @@ else
     LOCAL_SHARED_LIBRARIES := \
         libcap \
         libssl
-        
+
     LOCAL_STATIC_LIBRARIES := \
         libwebsockets
 endif
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/media_synchroniser \
                     $(LOCAL_PATH)/app2app
-                    
+
 ifeq ($(ORB_HBBTV_VERSION),204)
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/json_rpc_server
 endif
@@ -78,12 +72,6 @@ ifeq ($(USE_JSONCPP_ORB), 1)
 else
     LOCAL_STATIC_LIBRARIES += libjsoncpp
 endif
-
-LOCAL_CFLAGS +=  \
-   -DJSONCPP_VERSION_1_9_4=$(JSONCPP_VERSION_1_9_4)
-
-LOCAL_CFLAGS += \
-   -DLWS_VERSION_4=$(LWS_VERSION_4)
 
 LOCAL_CPPFLAGS += -fexceptions \
                   -frtti

--- a/components/network_services/UdpSocketService.cpp
+++ b/components/network_services/UdpSocketService.cpp
@@ -79,10 +79,13 @@ bool UdpSocketService::Start()
         vhost_ = lws_create_vhost(context_, &info_);
         if (vhost_)
         {
-#if LWS_VERSION_4 == 1
+#if LWS_LIBRARY_VERSION_NUMBER > 4002000
             if (lws_create_adopt_udp(vhost_, NULL, port_, LWS_CAUDP_BIND,
                 protocols_[0].name, NULL, NULL, NULL, NULL,
                 "user"))
+#elif LWS_LIBRARY_VERSION_NUMBER > 4000000
+            if (lws_create_adopt_udp(vhost_, NULL, port_, LWS_CAUDP_BIND,
+                protocols_[0].name, NULL, NULL, NULL, NULL))
 #else
             if (lws_create_adopt_udp(vhost_, port_, LWS_CAUDP_BIND,
                 protocols_[0].name, NULL))
@@ -218,7 +221,7 @@ int UdpSocketService::LwsCallback(struct lws *wsi, enum lws_callback_reasons rea
                     struct lws_udp udp = *(lws_get_udp(wsi));
                     void *d = std::get<0>(data);
                     int size = std::get<1>(data);
-#if LWS_VERSION_4 == 1
+#if LWS_LIBRARY_VERSION_NUMBER > 4002000
                     size_t bytesSent = sendto(fd, d, size, 0,
                         sa46_sockaddr(&udp.sa46),
                         sa46_socklen(&udp.sa46));

--- a/components/network_services/app2app/app2app_local_service.h
+++ b/components/network_services/app2app/app2app_local_service.h
@@ -52,7 +52,7 @@ private:
 
     ServiceManager *manager_;
     App2AppRemoteService remote_service_;
-    std::recursive_mutex mutex_;
+    std::recursive_mutex mMutex;
     std::unordered_map<std::string, std::deque<WebSocketConnection *> > waiting_connections_;
     bool service_stopped_;
     bool remote_service_stopped_;

--- a/components/network_services/json_rpc/JsonRpcService.cpp
+++ b/components/network_services/json_rpc/JsonRpcService.cpp
@@ -288,9 +288,9 @@ void JsonRpcService::OnMessageReceived(WebSocketConnection *connection, const st
 
 void JsonRpcService::OnDisconnected(WebSocketConnection *connection)
 {
-    connections_mutex_.lock();
+    WssMutexLock();
     m_connectionData.erase(connection->Id());
-    connections_mutex_.unlock();
+    WssMutexUnlock();
 }
 
 void JsonRpcService::OnServiceStopped()
@@ -1458,7 +1458,7 @@ void JsonRpcService::SendJsonMessageToClient(int connectionId,
 {
     Json::FastWriter writer;
     std::string message = writer.write(jsonResponse);
-    connections_mutex_.lock();
+    WssMutexLock();
     WebSocketConnection *connection = GetConnection(connectionId);
     if (connection != nullptr)
     {
@@ -1466,7 +1466,7 @@ void JsonRpcService::SendJsonMessageToClient(int connectionId,
         oss << message;
         connection->SendMessage(oss.str());
     }
-    connections_mutex_.unlock();
+    WssMutexUnlock();
 }
 
 /**
@@ -1705,13 +1705,13 @@ void JsonRpcService::CheckIntentMethod(std::vector<int> &result, const std::stri
  */
 std::vector<int> JsonRpcService::GetAllConnectionIds()
 {
-    connections_mutex_.lock();
+    WssMutexLock();
     std::vector<int> connectionIds;
     for (const auto& entry : m_connectionData)
     {
         connectionIds.push_back(entry.first);
     }
-    connections_mutex_.unlock();
+    WssMutexUnlock();
     return connectionIds;
 }
 
@@ -1722,10 +1722,10 @@ std::vector<int> JsonRpcService::GetAllConnectionIds()
  */
 void JsonRpcService::InitialConnectionData(int connectionId)
 {
-    connections_mutex_.lock();
+    WssMutexLock();
     m_connectionData[connectionId].intentIdCount = 0;
     m_connectionData[connectionId].negotiateMethodsAppToTerminal.insert(MD_NEGOTIATE_METHODS);
-    connections_mutex_.unlock();
+    WssMutexUnlock();
 }
 
 /**
@@ -1738,7 +1738,7 @@ void JsonRpcService::InitialConnectionData(int connectionId)
 void JsonRpcService::SetConnectionData(int connectionId, ConnectionDataType type, const
     Json::Value& value)
 {
-    connections_mutex_.lock();
+    WssMutexLock();
     if (m_connectionData.find(connectionId) == m_connectionData.end())
     {
         return;
@@ -1768,7 +1768,7 @@ void JsonRpcService::SetConnectionData(int connectionId, ConnectionDataType type
         default:
             break;
     }
-    connections_mutex_.unlock();
+    WssMutexUnlock();
 }
 
 /**
@@ -1780,7 +1780,7 @@ void JsonRpcService::SetConnectionData(int connectionId, ConnectionDataType type
 void JsonRpcService::SetStateMediaToConnectionData(int connectionId, const
     ConnectionData& mediaData)
 {
-    connections_mutex_.lock();
+    WssMutexLock();
     if (m_connectionData.find(connectionId) == m_connectionData.end())
     {
         return;
@@ -1803,7 +1803,7 @@ void JsonRpcService::SetStateMediaToConnectionData(int connectionId, const
     connectionData.mediaId = mediaData.mediaId;
     connectionData.secondTitle = mediaData.secondTitle;
     connectionData.synopsis = mediaData.synopsis;
-    connections_mutex_.unlock();
+    WssMutexUnlock();
 }
 
 /**
@@ -1826,7 +1826,7 @@ void JsonRpcService::SetStateMediaToConnectionData(int connectionId, const
  */
 Json::Value JsonRpcService::GetConnectionData(int connectionId, ConnectionDataType type)
 {
-    connections_mutex_.lock();
+    WssMutexLock();
     Json::Value value;
 
     if (m_connectionData.find(connectionId) != m_connectionData.end())
@@ -1913,7 +1913,7 @@ Json::Value JsonRpcService::GetConnectionData(int connectionId, ConnectionDataTy
                 break;
         }
     }
-    connections_mutex_.unlock();
+    WssMutexUnlock();
     return value;
 }
 

--- a/components/network_services/log.h
+++ b/components/network_services/log.h
@@ -26,12 +26,18 @@
 #define LOG_INFO ANDROID_LOG_INFO
 #define LOG_DEBUG ANDROID_LOG_DEBUG
 #define LOG(level, args ...) __android_log_print(level, LOG_TAG, args)
+#define LOGE(args ...) __android_log_print(LOG_ERROR, LOG_TAG, args);
+#define LOGI(args ...) __android_log_print(LOG_INFO, LOG_TAG, args);
+#define LOGD(args ...) __android_log_print(LOG_DEBUG, LOG_TAG, args);
 #define ASSERT(condition) assert(condition)
 #else
 #define LOG_ERROR 0
 #define LOG_INFO 1
 #define LOG_DEBUG 2
 #define LOG(level, args ...)
+#define LOGE(args ...)
+#define LOGI(args ...)
+#define LOGD(args ...)
 #define ASSERT(condition)
 #endif
 #endif // __MANAGER_LOG_H

--- a/components/network_services/media_synchroniser/CSSUtilities.cpp
+++ b/components/network_services/media_synchroniser/CSSUtilities.cpp
@@ -45,7 +45,7 @@ namespace NetworkServices {
 namespace CSSUtilities {
 bool unpack(const std::string &msg, Json::Value &msgToJson)
 {
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
     Json::CharReaderBuilder builder = {};
     auto reader = std::unique_ptr<Json::CharReader>(builder.newCharReader());
 
@@ -64,7 +64,7 @@ bool unpack(const std::string &msg, Json::Value &msgToJson)
 #endif
     if (!is_parsed)
     {
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
         LOG(LOG_ERROR, "CSSUtilities::unpack ERROR: Could not parse! %s\n", errors.c_str());
 #else
         LOG(LOG_ERROR, "CSSUtilities::unpack ERROR: Could not parse!\n");

--- a/components/network_services/media_synchroniser/ContentIdentificationService.cpp
+++ b/components/network_services/media_synchroniser/ContentIdentificationService.cpp
@@ -219,7 +219,7 @@ std::string ContentIdentificationService::pack(const Json::Value &currentMessage
 
     LOG(LOG_DEBUG, "ContentIdentificationService::pack:: \n%s\n",
         currentMessage.toStyledString().c_str());
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
     return Json::writeString(m_wbuilder, currentMessage);
 #else
     return m_writer.write(currentMessage);

--- a/components/network_services/media_synchroniser/ContentIdentificationService.h
+++ b/components/network_services/media_synchroniser/ContentIdentificationService.h
@@ -93,7 +93,7 @@ public:
 private:
     ContentIdentificationProperties *m_properties;
     Json::Value m_previousMessage;
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
     Json::StreamWriterBuilder m_wbuilder;
 #else
     Json::FastWriter m_writer;

--- a/components/network_services/media_synchroniser/ContentIdentificationService.h
+++ b/components/network_services/media_synchroniser/ContentIdentificationService.h
@@ -81,14 +81,11 @@ public:
 
     void OnDisconnected(WebSocketConnection *connection) override;
 
-    void updateClients(bool onlydiff);
+    void UpdateClient(WebSocketConnection *connection) override;
+
+    void OnUpdateClients() override;
 
     bool setCIIMessageProperty(const std::string &key, const Json::Value &value);
-
-    int nrOfClients() const
-    {
-        return connections_.size();
-    }
 
 private:
     ContentIdentificationProperties *m_properties;
@@ -100,8 +97,6 @@ private:
 #endif
     std::stringstream m_pattern;
 
-    std::string pack(const Json::Value &currentMessage, bool onlydiff, bool alwaysSendTimelines =
-            true);
 };
 }
 #endif //WIP_DVBCSS_HBBTV_CONTENTIDENTIFICATIONSERVICE_H

--- a/components/network_services/media_synchroniser/TimelineSyncService.cpp
+++ b/components/network_services/media_synchroniser/TimelineSyncService.cpp
@@ -536,7 +536,7 @@ void TimelineSyncService::updateClient(WebSocketService::WebSocketConnection *co
             m_connectionPreviousControlTimestamp[connection] = ct;
             LOG(LOG_DEBUG, "Current Control timestamp: %s\n",
                 ct.value().pack().toStyledString().c_str());
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
             connection->SendMessage(Json::writeString(m_wbuilder, ct.value().pack()));
 #else
             connection->SendMessage(m_writer.write(ct.value().pack()));

--- a/components/network_services/media_synchroniser/TimelineSyncService.cpp
+++ b/components/network_services/media_synchroniser/TimelineSyncService.cpp
@@ -382,7 +382,7 @@ void SimpleClockTimelineSource::notify()
         {
             if (sink.second)
             {
-                sink.first->updateAllClients();
+                sink.first->UpdateClients();
             }
         }
     }
@@ -410,8 +410,8 @@ void TimelineSyncService::setContentId(const std::string &cid, const bool forceU
             m_ciiService->setCIIMessageProperty("contentId", getContentId());
             if (forceUpdate)
             {
-                updateAllClients();
-                m_ciiService->updateClients(true);
+                UpdateClients();
+                m_ciiService->UpdateClients();
             }
         }
     }
@@ -435,8 +435,8 @@ void TimelineSyncService::setContentIdOverride(const std::string &cid, const boo
         m_ciiService->setCIIMessageProperty("contentIdStatus", "final");
         if (forceUpdate)
         {
-            updateAllClients();
-            m_ciiService->updateClients(true);
+            UpdateClients();
+            m_ciiService->UpdateClients();
         }
     }
 }
@@ -498,15 +498,7 @@ void TimelineSyncService::OnMessageReceived(WebSocketService::WebSocketConnectio
     }
 }
 
-void TimelineSyncService::updateAllClients()
-{
-    for (auto const &connection : connections_)
-    {
-        updateClient(connection.second.get());
-    }
-}
-
-void TimelineSyncService::updateClient(WebSocketService::WebSocketConnection *connection)
+void TimelineSyncService::UpdateClient(WebSocketService::WebSocketConnection *connection)
 {
     if (!m_connectionSetupData[connection].isEmpty())
     {
@@ -635,7 +627,7 @@ void TimelineSyncService::configureConnectionWithSetupData(
                     src.first->timelineSelectorNeeded(tSel);
                 }
             }
-            updateClient(connection);
+            UpdateClient(connection);
         }
     }
 }

--- a/components/network_services/media_synchroniser/TimelineSyncService.h
+++ b/components/network_services/media_synchroniser/TimelineSyncService.h
@@ -354,7 +354,7 @@ private:
     std::unordered_map<WebSocketConnection *, SetupTSData> m_connectionSetupData;
     std::unordered_map<WebSocketConnection *,
                        Nullable<ControlTimestamp> > m_connectionPreviousControlTimestamp;
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
     Json::StreamWriterBuilder m_wbuilder;
 #else
     Json::FastWriter m_writer;

--- a/components/network_services/media_synchroniser/TimelineSyncService.h
+++ b/components/network_services/media_synchroniser/TimelineSyncService.h
@@ -330,9 +330,7 @@ public:
 
     void OnDisconnected(WebSocketConnection *connection) override;
 
-    void updateAllClients();
-
-    void updateClient(WebSocketConnection *connection);
+    void UpdateClient(WebSocketConnection *connection) override;
 
     void attachTimelineSource(TimelineSource *);
 

--- a/components/network_services/media_synchroniser/media_synchroniser.cpp
+++ b/components/network_services/media_synchroniser/media_synchroniser.cpp
@@ -791,7 +791,7 @@ void MediaSynchroniser::removeTimeline(const std::string &timelineSelector)
     if (tls != nullptr)
     {
         Json::Value temp = m_ciiProps.getProperty("timelines");
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
 #else
         Json::Value newTimeline;
         int count = 0;
@@ -799,7 +799,7 @@ void MediaSynchroniser::removeTimeline(const std::string &timelineSelector)
         for (Json::Value::ArrayIndex i = 0; i != temp.size(); i++)
         {
             const Json::Value &jobj = temp[i];
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
             if (jobj["timelineSelector"] == timelineSelector)
             {
                 Json::Value removed;
@@ -816,7 +816,7 @@ void MediaSynchroniser::removeTimeline(const std::string &timelineSelector)
             }
 #endif
         }
-#if JSONCPP_VERSION_1_9_4 == 1
+#if JSONCPP_VERSION_HEXA > 0x01080200
 #else
         if (newTimeline.size() > 0)
         {

--- a/components/network_services/media_synchroniser/media_synchroniser.cpp
+++ b/components/network_services/media_synchroniser/media_synchroniser.cpp
@@ -371,7 +371,7 @@ int MediaSynchroniser::nrOfSlaves()
         ServiceManager::GetInstance().FindService<ContentIdentificationService>(m_ciiService);
     if (cii != nullptr)
     {
-        ret = cii->nrOfClients();
+        ret = cii->TotalClients();
     }
     return ret;
 }
@@ -383,7 +383,7 @@ void MediaSynchroniser::updateAllCIIClients()
         ServiceManager::GetInstance().FindService<ContentIdentificationService>(m_ciiService);
     if (cii != nullptr)
     {
-        cii->updateClients(true);
+        cii->UpdateClients();
     }
 }
 
@@ -394,7 +394,7 @@ void MediaSynchroniser::updateAllTSClients()
     LOG(LOG_DEBUG, "MediaSynchroniser::updateAllTSClients(). tsService: %p\n", ts);
     if (ts != nullptr)
     {
-        ts->updateAllClients();
+        ts->UpdateClients();
     }
 }
 

--- a/components/network_services/websocket_service.cpp
+++ b/components/network_services/websocket_service.cpp
@@ -251,7 +251,9 @@ void WebSocketService::Stop()
         mMainThread = (pthread_t)0;
         LOGD("[%d]  Stopped", mSid)
     }
-
+    // Call OnServiceStopped() after the thread has exited to avoid any potential
+    // deadlocks or blocking operations in the MainLooper thread
+    OnServiceStopped();
 }
 
 void * WebSocketService::EnterMainLooper(void *instance)
@@ -279,7 +281,6 @@ void WebSocketService::MainLooper()
         mConnectionsMutex.lock();
     }
     mConnectionsMutex.unlock();
-    OnServiceStopped();
     LOGD("[%d] exit MainLooper", mSid)
 }
 

--- a/components/network_services/websocket_service.cpp
+++ b/components/network_services/websocket_service.cpp
@@ -67,7 +67,7 @@ WebSocketService::WebSocketService(const std::string &protocol_name, int port, b
     protocol_name_(protocol_name),
     use_ssl_(use_ssl),
     interface_name_(interface_name),
-#if LWS_VERSION_4 == 1
+#if LWS_LIBRARY_VERSION_NUMBER > 4000000
     retry_{.secs_since_valid_ping = SECS_SINCE_VALID_PING, .secs_since_valid_hangup =
                SECS_SINCE_VALID_HANGUP},
 #endif
@@ -81,7 +81,7 @@ WebSocketService::WebSocketService(const std::string &protocol_name, int port, b
         .options = LWS_SERVER_OPTION_HTTP_HEADERS_SECURITY_BEST_PRACTICES_ENFORCE
             /* | LWS_SERVER_OPTION_VHOST_UPG_STRICT_HOST_CHECK */,
         .vhost_name = VHOST_NAME,
-#if LWS_VERSION_4 == 1
+#if LWS_LIBRARY_VERSION_NUMBER > 4000000
         .retry_and_idle_policy = &retry_,
 #endif
     };

--- a/components/network_services/websocket_service.cpp
+++ b/components/network_services/websocket_service.cpp
@@ -20,14 +20,16 @@
 #define         LWS_PROTOCOL_LIST_TERM   { NULL, NULL, 0, 0, 0, NULL, 0 }
 
 namespace NetworkServices {
-#define VHOST_NAME "localhost"
-#define SSL_CERT_FILEPATH "todo.cert"
-#define SSL_PRIVATE_KEY_FILEPATH "todo.key"
-#define SECS_SINCE_VALID_PING 3
-#define SECS_SINCE_VALID_HANGUP 10
-#define RX_BUFFER_SIZE 4096
 
-static int next_connection_id_ = 0;
+static int sNextConnectionId = 0;
+
+// Implementation of WebSocketConnection methods
+
+WebSocketService::WebSocketConnection::WebSocketConnection(struct lws *wsi, const std::string &uri)
+    : mWsi(wsi), mUri(uri), mTextBuffer(""), mPairedConnection(nullptr)
+{
+    mId = sNextConnectionId++;
+}
 
 void WebSocketService::WebSocketConnection::SendMessage(const std::string &text)
 {
@@ -48,8 +50,20 @@ void WebSocketService::WebSocketConnection::SendFragment(std::vector<uint8_t> &&
         .write_protocol = static_cast<lws_write_protocol>(protocol),
         .data = std::move(data),
     };
-    write_queue_.emplace(fragment);
-    lws_callback_on_writable(wsi_);
+    mWriteQueue.emplace(fragment);
+    lws_callback_on_writable(mWsi);
+}
+
+bool WebSocketService::WebSocketConnection::ClosePaired()
+{
+    if (mPairedConnection ==  nullptr)
+    {
+        return false;
+    }
+    mPairedConnection->mPairedConnection = nullptr;
+    mPairedConnection->Close();
+    mPairedConnection = nullptr;
+    return true;
 }
 
 void WebSocketService::WebSocketConnection::Close()
@@ -57,43 +71,43 @@ void WebSocketService::WebSocketConnection::Close()
     struct FragmentWriteInfo fragment = {
         .close = true,
     };
-    write_queue_.emplace(fragment);
-    lws_callback_on_writable(wsi_);
+    mWriteQueue.emplace(fragment);
+    lws_callback_on_writable(mWsi);
 }
 
 WebSocketService::WebSocketService(const std::string &protocol_name, int port, bool use_ssl,
                                    const std::string &interface_name) :
-    stop_(true),
-    protocol_name_(protocol_name),
-    use_ssl_(use_ssl),
-    interface_name_(interface_name),
+    mStop(true),
+    mProtocolName(protocol_name),
+    mUseSSL(use_ssl),
+    mInterfaceName(interface_name),
 #if LWS_LIBRARY_VERSION_NUMBER > 4000000
-    retry_{.secs_since_valid_ping = SECS_SINCE_VALID_PING, .secs_since_valid_hangup =
+    mRetry{.secs_since_valid_ping = SECS_SINCE_VALID_PING, .secs_since_valid_hangup =
                SECS_SINCE_VALID_HANGUP},
 #endif
-    protocols_{Protocol(protocol_name_.c_str()), LWS_PROTOCOL_LIST_TERM},
-    context_(nullptr)
+    mProtocols{Protocol(mProtocolName.c_str()), LWS_PROTOCOL_LIST_TERM},
+    mContext(nullptr)
 {
-    info_ =
+    mContextInfo =
     {
-        .protocols = protocols_,
+        .protocols = mProtocols,
         .port = port,
         .options = LWS_SERVER_OPTION_HTTP_HEADERS_SECURITY_BEST_PRACTICES_ENFORCE
             /* | LWS_SERVER_OPTION_VHOST_UPG_STRICT_HOST_CHECK */,
-        .vhost_name = VHOST_NAME,
+        .vhost_name = VHOST_NAME.c_str(),
 #if LWS_LIBRARY_VERSION_NUMBER > 4000000
-        .retry_and_idle_policy = &retry_,
+        .retry_and_idle_policy = &mRetry,
 #endif
     };
-    if (use_ssl_)
+    if (mUseSSL)
     {
-        info_.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
-        info_.ssl_cert_filepath = SSL_CERT_FILEPATH;
-        info_.ssl_private_key_filepath = SSL_PRIVATE_KEY_FILEPATH;
+        mContextInfo.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
+        mContextInfo.ssl_cert_filepath = SSL_CERT_FILEPATH.c_str();
+        mContextInfo.ssl_private_key_filepath = SSL_PRIVATE_KEY_FILEPATH.c_str();
     }
-    if (!interface_name_.empty())
+    if (!mInterfaceName.empty())
     {
-        info_.iface = interface_name_.c_str();
+        mContextInfo.iface = mInterfaceName.c_str();
     }
     lws_set_log_level(LLL_ERR | LLL_WARN /*| LLL_NOTICE*/, nullptr);
 }
@@ -101,35 +115,36 @@ WebSocketService::WebSocketService(const std::string &protocol_name, int port, b
 bool WebSocketService::Start()
 {
     bool ret = false;
-    connections_mutex_.lock();
-    if (context_ == nullptr && (context_ = lws_create_context(&info_)) != nullptr)
+    mConnectionsMutex.lock();
+    if (mContext == nullptr
+        && (mContext = lws_create_context(&mContextInfo)) != nullptr)
     {
-        stop_ = false;
+        mStop = false;
         pthread_t thread;
         pthread_create(&thread, nullptr, EnterMainLooper, this);
-        connections_mutex_.unlock();
+        mConnectionsMutex.unlock();
         ret = true;
     }
-    connections_mutex_.unlock();
+    mConnectionsMutex.unlock();
     return ret;
 }
 
 void WebSocketService::Stop()
 {
-    connections_mutex_.lock();
-    stop_ = true;
-    if (connections_.size() > 0)
+    mConnectionsMutex.lock();
+    mStop = true;
+    if (mConnections.size() > 0)
     {
-        for (auto &it : connections_)
+        for (auto &it : mConnections)
         {
             it.second->Close();
         }
     }
-    else if (context_ != nullptr)
+    else if (mContext != nullptr)
     {
-        lws_cancel_service(context_);
+        lws_cancel_service(mContext);
     }
-    connections_mutex_.unlock();
+    mConnectionsMutex.unlock();
 }
 
 void * WebSocketService::EnterMainLooper(void *instance)
@@ -140,26 +155,26 @@ void * WebSocketService::EnterMainLooper(void *instance)
 
 void WebSocketService::MainLooper()
 {
-    connections_mutex_.lock();
-    while (!stop_ || connections_.size() > 0)
+    mConnectionsMutex.lock();
+    while (!mStop || mConnections.size() > 0)
     {
-        connections_mutex_.unlock();
-        if (lws_service(context_, 0) < 0)
+        mConnectionsMutex.unlock();
+        if (lws_service(mContext, 0) < 0)
         {
-            connections_mutex_.lock();
-            stop_ = true;
-            connections_.clear();
-            lws_cancel_service(context_);
+            mConnectionsMutex.lock();
+            mStop = true;
+            mConnections.clear();
+            lws_cancel_service(mContext);
             break;
         }
-        connections_mutex_.lock();
+        mConnectionsMutex.lock();
     }
-    if (context_ != nullptr)
+    if (mContext != nullptr)
     {
-        lws_context_destroy(context_);
-        context_ = nullptr;
+        lws_context_destroy(mContext);
+        mContext = nullptr;
     }
-    connections_mutex_.unlock();
+    mConnectionsMutex.unlock();
     OnServiceStopped();
 }
 
@@ -179,7 +194,7 @@ int WebSocketService::LwsCallback(struct lws *wsi, enum lws_callback_reasons rea
     void *user, void *in, size_t len)
 {
     int result = 0;
-    connections_mutex_.lock();
+    mConnectionsMutex.lock();
     switch (reason)
     {
         case LWS_CALLBACK_PROTOCOL_INIT: {
@@ -200,38 +215,38 @@ int WebSocketService::LwsCallback(struct lws *wsi, enum lws_callback_reasons rea
                 result = -1;
                 break;
             }
-            connections_[user] = std::move(connection);
+            mConnections[user] = std::move(connection);
             break;
         }
 
         case LWS_CALLBACK_CLOSED: {
-            auto it = connections_.find(user);
-            if (it == connections_.end())
+            auto it = mConnections.find(user);
+            if (it == mConnections.end())
             {
                 result = -1;
                 break;
             }
             OnDisconnected(it->second.get());
-            connections_.erase(it);
+            mConnections.erase(it);
 
-            if (stop_ && connections_.size() <= 0 && context_ != nullptr)
+            if (mStop && mConnections.size() <= 0 && mContext != nullptr)
             {
-                lws_cancel_service(context_);
+                lws_cancel_service(mContext);
             }
             break;
         }
 
         case LWS_CALLBACK_SERVER_WRITEABLE: {
-            auto it = connections_.find(user);
-            if (it == connections_.end())
+            auto it = mConnections.find(user);
+            if (it == mConnections.end())
             {
                 result = -1;
                 break;
             }
-            while (!it->second->write_queue_.empty())
+            while (!it->second->mWriteQueue.empty())
             {
-                auto fragment = std::move(it->second->write_queue_.front());
-                it->second->write_queue_.pop();
+                auto fragment = std::move(it->second->mWriteQueue.front());
+                it->second->mWriteQueue.pop();
                 if (fragment.close)
                 {
                     lws_close_reason(wsi, LWS_CLOSE_STATUS_GOINGAWAY, nullptr, 0);
@@ -251,8 +266,8 @@ int WebSocketService::LwsCallback(struct lws *wsi, enum lws_callback_reasons rea
         }
 
         case LWS_CALLBACK_RECEIVE: {
-            auto it = connections_.find(user);
-            if (it == connections_.end())
+            auto it = mConnections.find(user);
+            if (it == mConnections.end())
             {
                 result = -1;
                 break;
@@ -267,7 +282,7 @@ int WebSocketService::LwsCallback(struct lws *wsi, enum lws_callback_reasons rea
             break;
         }
     }
-    connections_mutex_.unlock();
+    mConnectionsMutex.unlock();
     return result;
 }
 
@@ -279,18 +294,18 @@ void WebSocketService::OnFragmentReceived(WebSocketConnection *connection,
     {
         if (is_first)
         {
-            connection->text_buffer_ = std::string(reinterpret_cast<char *>(data.data()),
+            connection->mTextBuffer = std::string(reinterpret_cast<char *>(data.data()),
                 data.size());
         }
         else
         {
-            connection->text_buffer_ += std::string(reinterpret_cast<char *>(data.data()),
+            connection->mTextBuffer += std::string(reinterpret_cast<char *>(data.data()),
                 data.size());
         }
 
         if (is_final)
         {
-            OnMessageReceived(connection, connection->text_buffer_);
+            OnMessageReceived(connection, connection->mTextBuffer);
         }
     }
     else
@@ -302,6 +317,54 @@ void WebSocketService::OnFragmentReceived(WebSocketConnection *connection,
 void WebSocketService::OnMessageReceived(WebSocketConnection *connection, const std::string &text)
 {
     // Possibly called by the implementation of OnFragmentReceived
+}
+
+void WebSocketService::UpdateClient(WebSocketConnection *connection)
+{
+    // Overriden by sub class
+}
+
+void WebSocketService::OnUpdateClients()
+{
+    // Overriden by sub class
+}
+
+void WebSocketService::UpdateClients()
+{
+    for (auto const &connection : mConnections)
+    {
+        UpdateClient(connection.second.get());
+    }
+    OnUpdateClients();
+}
+
+int WebSocketService::TotalClients() const
+{
+    int total;
+    total = mConnections.size();
+    return total;
+}
+
+WebSocketService::WebSocketConnection* WebSocketService::GetConnection(int id)
+{
+    for (auto &connection : mConnections)
+    {
+        if (connection.second->mId == id)
+        {
+            return connection.second.get();
+        }
+    }
+    return nullptr;
+}
+
+void WebSocketService::WssMutexLock()
+{
+    mConnectionsMutex.lock();
+}
+
+void WebSocketService::WssMutexUnlock()
+{
+    mConnectionsMutex.unlock();
 }
 
 struct lws_protocols WebSocketService::Protocol(const char *protocol_name)
@@ -332,9 +395,5 @@ std::string WebSocketService::Header(struct lws *wsi, enum lws_token_indexes hea
     return "";
 }
 
-WebSocketService::WebSocketConnection::WebSocketConnection(struct lws *wsi, const std::string &uri)
-    : wsi_(wsi), uri_(uri), paired_connection_(nullptr)
-{
-    id_ = next_connection_id_++;
-}
+
 } // namespace NetworkServices

--- a/components/network_services/websocket_service.h
+++ b/components/network_services/websocket_service.h
@@ -109,7 +109,9 @@ private:
 
     bool stop_;
     std::string protocol_name_;
+#if LWS_LIBRARY_VERSION_NUMBER > 4000000
     lws_retry_bo_t retry_;
+#endif
     struct lws_protocols protocols_[2];
     struct lws_context_creation_info info_;
     bool use_ssl_;

--- a/components/network_services/websocket_service.h
+++ b/components/network_services/websocket_service.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <queue>
 #include <mutex>
+#include <pthread.h>
 #include <libwebsockets.h>
 
 namespace NetworkServices {
@@ -44,6 +45,7 @@ public:
 public:
 
         WebSocketConnection(struct lws *wsi, const std::string &uri);
+        virtual ~WebSocketConnection();
 
         std::string Uri() const
         {
@@ -93,7 +95,7 @@ private:
 
     WebSocketService(const std::string &server_name, int port, bool use_ssl, const
         std::string &interface_name);
-    virtual ~WebSocketService() = default;
+    virtual ~WebSocketService();
     virtual bool Start();
     virtual void Stop();
     virtual bool OnConnection(WebSocketConnection *connection) = 0;
@@ -125,6 +127,7 @@ private:
     std::unordered_map<void *, std::unique_ptr<WebSocketConnection> > mConnections;
 
     bool mStop;
+    int mSid;
     std::string mProtocolName;
     bool mUseSSL;
     std::string mInterfaceName;
@@ -134,6 +137,7 @@ private:
     struct lws_protocols mProtocols[2];
     struct lws_context_creation_info mContextInfo;
     struct lws_context *mContext;
+    pthread_t mMainThread;
 };
 } // namespace NetworkServices
 


### PR DESCRIPTION
Fix crash where worker thread was still running after destruction of WebSocket server.
Fix connection shut down so that don't leave port hanging and still in use after destruction of server.
Better encapsulation of web socket server class
Use defines provided in third party library headers for macro checks on code affected by API changes in those libs
Also, removed use of symlinks so that can use Windows GIT tools